### PR TITLE
Add support for managed identity

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.8.2" />
     <PackageVersion Include="Bogus" Version="34.0.2" />
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.3" />

--- a/src/LogOtter.CosmosDb/Configure/CosmosDbOptions.cs
+++ b/src/LogOtter.CosmosDb/Configure/CosmosDbOptions.cs
@@ -6,6 +6,7 @@ public record CosmosDbOptions
 {
     public string ConnectionString { get; set; } = "";
     public string DatabaseId { get; set; } = "";
+    public ManagedIdentityOptions? ManagedIdentityOptions { get; set; }
     public ChangeFeedProcessorOptions ChangeFeedProcessorOptions { get; set; } = new();
     public CosmosClientOptions? ClientOptions { get; set; }
 }

--- a/src/LogOtter.CosmosDb/Configure/CosmosDbOptionsValidator.cs
+++ b/src/LogOtter.CosmosDb/Configure/CosmosDbOptionsValidator.cs
@@ -6,7 +6,14 @@ internal class CosmosDbOptionsValidator : IValidateOptions<CosmosDbOptions>
 {
     public ValidateOptionsResult Validate(string? name, CosmosDbOptions options)
     {
-        if (string.IsNullOrWhiteSpace(options.ConnectionString))
+        if (options.ManagedIdentityOptions != null)
+        {
+            if (string.IsNullOrWhiteSpace(options.ManagedIdentityOptions.AccountEndpoint))
+            {
+                return ValidateOptionsResult.Fail("ManagedIdentityOptions.AccountEndpoint not specified");
+            }
+        }
+        else if (string.IsNullOrWhiteSpace(options.ConnectionString))
         {
             return ValidateOptionsResult.Fail("ConnectionString not specified");
         }

--- a/src/LogOtter.CosmosDb/Configure/ManagedIdentityOptions.cs
+++ b/src/LogOtter.CosmosDb/Configure/ManagedIdentityOptions.cs
@@ -1,0 +1,7 @@
+namespace LogOtter.CosmosDb;
+
+public record ManagedIdentityOptions
+{
+    public string AccountEndpoint { get; set; } = "";
+    public string? UserAssignedManagedIdentityClientId { get; set; }
+}

--- a/src/LogOtter.CosmosDb/LogOtter.CosmosDb.csproj
+++ b/src/LogOtter.CosmosDb/LogOtter.CosmosDb.csproj
@@ -11,6 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Identity" />
         <PackageReference Include="Microsoft.Azure.Cosmos" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Hosting" />


### PR DESCRIPTION
I've added some initial support for managed identity. If the option block is specified then it'll validate that an account endpoint has been provided. If UserAssignedManagedIdentityClientId is also specified then it'll use that identity, otherwise it'll attempt to use the system assigned MI.

I also noticed when running the tests that it would always try and start a docker container. As the emulator doesn't work on M1 macs I couldn't do that. I've tweaked so that it checks the _useTestContainers flag that was already there, and doesn't try to do anything with Docker if it's false (when the env variable has been set)