### PR TITLE
Switch to using the environment variables being written in the previous step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: ["published"]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tested in this pre release package: https://github.com/LogOtter/log-otter/releases/tag/v0.1.1-alpha3