### PR TITLE
Add AutoProvision support for Indexing Policy

### DIFF
--- a/build/Generate-DevToken.ps1
+++ b/build/Generate-DevToken.ps1
@@ -1,0 +1,22 @@
+$ErrorActionPreference = 'Stop'
+
+$solutionDir = Split-Path $PSScriptRoot
+$customerApiProjectDir = Join-Path $solutionDir 'sample' 'CustomerApi'
+$httpPrivateEnvFilename = Join-Path $customerApiProjectDir 'http-client.private.env.json'
+
+Write-Host 'Generating token...'
+
+Push-Location $customerApiProjectDir
+$token = & dotnet user-jwts create --name "Bob Bobertson" --role "Customers.Read" --role "Customers.ReadWrite" --role "Customers.Delete" --role "Customers.Create" --output token
+Pop-Location
+
+$httpEnvData = '{
+  "dev": {
+    "token": "' + $token + '"
+  }
+}'
+
+Write-Host 'Storing token...'
+$httpEnvData | Out-File $httpPrivateEnvFilename
+
+Write-Host 'Done!'

--- a/docs/BuildingLocally.md
+++ b/docs/BuildingLocally.md
@@ -14,6 +14,15 @@ cd sample\CustomerApi
 dotnet user-jwts create --name "Bob Bobertson" --role "Customers.Read" --role "Customers.ReadWrite" --role "Customers.Delete" --role "Customers.Create"
 ```
 
+### Generate token for `.http` files
+
+The `CustomerApi` sample contains a couple of `.http` files that can be used for calling the API during
+development. To quickly generate a token and add it to the the `http-client.private.env.json`, just run
+
+```pwsh
+.\build\Generate-DevToken.ps1
+```
+
 ## Integration Tests
 
 The `LogOtter.CosmosDb.ContainerMock.IntegrationTests` project uses Testcontainers to run

--- a/sample/CustomerApi/Helpers/OptionallyPatchedExtensions.cs
+++ b/sample/CustomerApi/Helpers/OptionallyPatchedExtensions.cs
@@ -1,0 +1,16 @@
+﻿using LogOtter.HttpPatch;
+
+namespace CustomerApi;
+
+public static class OptionallyPatchedExtensions
+{
+    public static bool IsIncludedInPatchAndIsDifferentFrom<T>(this OptionallyPatched<T> optionallyPatched, T value)
+    {
+        if (!optionallyPatched.IsIncludedInPatch)
+        {
+            return false;
+        }
+
+        return !EqualityComparer<T>.Default.Equals(optionallyPatched.Value, value);
+    }
+}

--- a/sample/CustomerApi/Program.cs
+++ b/sample/CustomerApi/Program.cs
@@ -43,14 +43,10 @@ services
             c.AddProjection<CustomerReadModel>()
                 .WithSnapshot("Customers", _ => CustomerReadModel.StaticPartitionKey)
                 .WithAutoProvisionSettings(
-                    compositeIndexes: new[]
-                    {
-                        new Collection<CompositePath>
-                        {
-                            new() { Path = "/LastName", Order = CompositePathSortOrder.Ascending },
-                            new() { Path = "/FirstName", Order = CompositePathSortOrder.Ascending }
-                        }
-                    }
+                    indexingPolicy: new IndexingPolicy().WithCompositeIndex(
+                        new() { Path = "/LastName", Order = CompositePathSortOrder.Ascending },
+                        new() { Path = "/FirstName", Order = CompositePathSortOrder.Ascending }
+                    )
                 );
 
             c.AddCatchupSubscription<TestCustomerEventCatchupSubscription>("TestCustomerEventCatchupSubscription");

--- a/sample/CustomerApi/http-client.env.json
+++ b/sample/CustomerApi/http-client.env.json
@@ -1,7 +1,7 @@
 ﻿{
   "dev": {
     "host": "https://localhost:7092",
-    "test-customer-id": "LQ7GdxMFKB5Bv06MFNY9JLsC",
+    "test-customer-id": "2bJ7qHf7p30B4cbqxnpH0pSC",
     "test-event-id": "32a71dcc-65c1-41a6-b9f9-59c90c4f9ca9"
   },
   "docker": {

--- a/src/LogOtter.CosmosDb.EventStore/Configure/SnapshotBuilder.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/SnapshotBuilder.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using LogOtter.CosmosDb.EventStore.Metadata;
+﻿using LogOtter.CosmosDb.EventStore.Metadata;
 using LogOtter.CosmosDb.Metadata;
 using Microsoft.Azure.Cosmos;
 
@@ -18,7 +17,7 @@ public class SnapshotBuilder<TBaseEvent, TProjection>
         string partitionKeyPath = "/partitionKey",
         UniqueKeyPolicy? uniqueKeyPolicy = null,
         int? defaultTimeToLive = -1,
-        IReadOnlyCollection<Collection<CompositePath>>? compositeIndexes = null,
+        IndexingPolicy? indexingPolicy = null,
         ThroughputProperties? throughputProperties = null
     )
     {
@@ -32,7 +31,7 @@ public class SnapshotBuilder<TBaseEvent, TProjection>
                             partitionKeyPath,
                             uniqueKeyPolicy,
                             defaultTimeToLive,
-                            compositeIndexes,
+                            indexingPolicy,
                             throughputProperties
                         )
                     }

--- a/src/LogOtter.CosmosDb.EventStore/EventStore/CosmosDbStorageEvent.cs
+++ b/src/LogOtter.CosmosDb.EventStore/EventStore/CosmosDbStorageEvent.cs
@@ -42,7 +42,8 @@ public class CosmosDbStorageEvent
             BodyType = typeMap.GetNameFromType(storageEvent.EventBody.GetType()),
             StreamId = storageEvent.StreamId,
             EventNumber = storageEvent.EventNumber,
-            Metadata = storageEvent.Metadata
+            Metadata = storageEvent.Metadata,
+            CreatedOn = storageEvent.CreatedOn
         };
 
         return cosmosDbStorageEvent;

--- a/src/LogOtter.CosmosDb.EventStore/Helpers/IndexingPolicyExtensions.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Helpers/IndexingPolicyExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.ObjectModel;
+using Microsoft.Azure.Cosmos;
+
+namespace LogOtter.CosmosDb.EventStore;
+
+public static class IndexingPolicyExtensions
+{
+    public static IndexingPolicy WithCompositeIndex(this IndexingPolicy indexingPolicy, params CompositePath[] compositePaths)
+    {
+        indexingPolicy.CompositeIndexes.Add(new Collection<CompositePath>(compositePaths.ToList()));
+
+        return indexingPolicy;
+    }
+}

--- a/src/LogOtter.CosmosDb.Testing/Containers/TestCosmosContainerFactory.cs
+++ b/src/LogOtter.CosmosDb.Testing/Containers/TestCosmosContainerFactory.cs
@@ -13,7 +13,7 @@ public class TestCosmosContainerFactory : ICosmosContainerFactory
         string partitionKeyPath,
         UniqueKeyPolicy? uniqueKeyPolicy = null,
         int? defaultTimeToLive = null,
-        IEnumerable<Collection<CompositePath>>? compositeIndexes = null,
+        IndexingPolicy? indexingPolicy = null,
         ThroughputProperties? throughputProperties = null
     )
     {

--- a/src/LogOtter.CosmosDb/Configure/ContainerConfiguration.cs
+++ b/src/LogOtter.CosmosDb/Configure/ContainerConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using LogOtter.CosmosDb.Metadata;
+﻿using LogOtter.CosmosDb.Metadata;
 using Microsoft.Azure.Cosmos;
 
 namespace LogOtter.CosmosDb;
@@ -19,17 +18,11 @@ public class ContainerConfiguration<TDocument>
         string partitionKeyPath = "/partitionKey",
         UniqueKeyPolicy? uniqueKeyPolicy = null,
         int? defaultTimeToLive = -1,
-        IReadOnlyCollection<Collection<CompositePath>>? compositeIndexes = null,
+        IndexingPolicy? indexingPolicy = null,
         ThroughputProperties? throughputProperties = null
     )
     {
-        AutoProvisionMetadata = new AutoProvisionMetadata(
-            partitionKeyPath,
-            uniqueKeyPolicy,
-            defaultTimeToLive,
-            compositeIndexes,
-            throughputProperties
-        );
+        AutoProvisionMetadata = new AutoProvisionMetadata(partitionKeyPath, uniqueKeyPolicy, defaultTimeToLive, indexingPolicy, throughputProperties);
 
         return this;
     }

--- a/src/LogOtter.CosmosDb/Configure/CosmosDbBuilder.cs
+++ b/src/LogOtter.CosmosDb/Configure/CosmosDbBuilder.cs
@@ -183,7 +183,7 @@ public class CosmosDbBuilder
                         autoProvisionMetadata.PartitionKeyPath,
                         autoProvisionMetadata.UniqueKeyPolicy,
                         autoProvisionMetadata.DefaultTimeToLive,
-                        autoProvisionMetadata.CompositeIndexes,
+                        autoProvisionMetadata.IndexingPolicy,
                         autoProvisionMetadata.ThroughputProperties
                     )
                     .GetAwaiter()

--- a/src/LogOtter.CosmosDb/Containers/CosmosContainerFactory.cs
+++ b/src/LogOtter.CosmosDb/Containers/CosmosContainerFactory.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using Microsoft.Azure.Cosmos;
 
 namespace LogOtter.CosmosDb;
@@ -17,7 +16,7 @@ public class CosmosContainerFactory : ICosmosContainerFactory
         string partitionKeyPath,
         UniqueKeyPolicy? uniqueKeyPolicy = null,
         int? defaultTimeToLive = null,
-        IEnumerable<Collection<CompositePath>>? compositeIndexes = null,
+        IndexingPolicy? indexingPolicy = null,
         ThroughputProperties? throughputProperties = null
     )
     {
@@ -28,12 +27,9 @@ public class CosmosContainerFactory : ICosmosContainerFactory
             containerProperties.UniqueKeyPolicy = uniqueKeyPolicy;
         }
 
-        if (compositeIndexes != null)
+        if (indexingPolicy != null)
         {
-            foreach (var index in compositeIndexes)
-            {
-                containerProperties.IndexingPolicy.CompositeIndexes.Add(index);
-            }
+            containerProperties.IndexingPolicy = indexingPolicy;
         }
 
         var containerResponse = await _database.CreateContainerIfNotExistsAsync(containerProperties, throughputProperties);

--- a/src/LogOtter.CosmosDb/Containers/ICosmosContainerFactory.cs
+++ b/src/LogOtter.CosmosDb/Containers/ICosmosContainerFactory.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using Microsoft.Azure.Cosmos;
 
 namespace LogOtter.CosmosDb;
@@ -10,7 +9,7 @@ public interface ICosmosContainerFactory
         string partitionKeyPath,
         UniqueKeyPolicy? uniqueKeyPolicy = null,
         int? defaultTimeToLive = null,
-        IEnumerable<Collection<CompositePath>>? compositeIndexes = null,
+        IndexingPolicy? indexingPolicy = null,
         ThroughputProperties? throughputProperties = null
     );
 

--- a/src/LogOtter.CosmosDb/Metadata/AutoProvisionMetadata.cs
+++ b/src/LogOtter.CosmosDb/Metadata/AutoProvisionMetadata.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.ObjectModel;
-using Microsoft.Azure.Cosmos;
+﻿using Microsoft.Azure.Cosmos;
 
 namespace LogOtter.CosmosDb.Metadata;
 
@@ -7,6 +6,6 @@ internal record AutoProvisionMetadata(
     string PartitionKeyPath = "/partitionKey",
     UniqueKeyPolicy? UniqueKeyPolicy = null,
     int? DefaultTimeToLive = -1,
-    IEnumerable<Collection<CompositePath>>? CompositeIndexes = null,
+    IndexingPolicy? IndexingPolicy = null,
     ThroughputProperties? ThroughputProperties = null
 );


### PR DESCRIPTION
We only supported `CompositeIndexes` with the Auto Provision settings previously. This meant we couldn't set up `IncludePaths` or `ExcludePaths`. 

`SimpleEventStore` excluded the `body` and `metadata` properties from the event documents previously and this PR does the same for our events.