### PR TITLE
Remove explicit nuget reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,6 @@
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="Testcontainers" Version="3.1.0" />
     <PackageVersion Include="Testcontainers.CosmosDb" Version="3.2.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />


### PR DESCRIPTION
Testcontainers is now referenced indirectly by Testcontainers.CosmosDb therefore an entry isn't needed in `Directory.Packages.props`. It doesn't really matter that it is there, but Dependabot will keep trying to upgrade the reference so better to clean it up.