### PR TITLE
Add support to define what containers are pre-provisioned in tests

### DIFF
--- a/sample/CustomerApi.Tests/CustomerController/CreateCustomerTests.cs
+++ b/sample/CustomerApi.Tests/CustomerController/CreateCustomerTests.cs
@@ -9,10 +9,12 @@ namespace CustomerApi.Tests.CustomerController;
 
 public class CreateCustomerTests
 {
-    [Fact]
-    public async Task Valid_ReturnsOk()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Valid_ReturnsOk(bool disableAutoProvisioning)
     {
-        using var customerApi = new TestCustomerApi();
+        using var customerApi = new TestCustomerApi(disableAutoProvisioning);
         var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Create");
 
         var client = customerApi.CreateClient(authHeader);
@@ -23,10 +25,12 @@ public class CreateCustomerTests
         response.StatusCode.Should().Be(HttpStatusCode.Created);
     }
 
-    [Fact]
-    public async Task Valid_StoredCorrectly()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Valid_StoredCorrectly(bool disableAutoProvisioning)
     {
-        using var customerApi = new TestCustomerApi();
+        using var customerApi = new TestCustomerApi(disableAutoProvisioning);
         var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Create");
 
         var client = customerApi.CreateClient(authHeader);

--- a/sample/CustomerApi.Tests/CustomerInterestsController/CreateCustomerInterestTests.cs
+++ b/sample/CustomerApi.Tests/CustomerInterestsController/CreateCustomerInterestTests.cs
@@ -9,10 +9,12 @@ namespace CustomerApi.Tests.CustomerInterestsController;
 
 public class CreateCustomerInterestTests
 {
-    [Fact]
-    public async Task ValidMovie_ReturnsOk()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ValidMovie_ReturnsOk(bool disableAutoProvisioning)
     {
-        using var customerApi = new TestCustomerApi();
+        using var customerApi = new TestCustomerApi(disableAutoProvisioning);
         var authHeader = await customerApi.Given.AnExistingConsumer("CustomerInterests.Create");
 
         var client = customerApi.CreateClient(authHeader);
@@ -23,10 +25,12 @@ public class CreateCustomerInterestTests
         response.StatusCode.Should().Be(HttpStatusCode.Created);
     }
 
-    [Fact]
-    public async Task ValidMovie_StoredCorrectly()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ValidMovie_StoredCorrectly(bool disableAutoProvisioning)
     {
-        using var customerApi = new TestCustomerApi();
+        using var customerApi = new TestCustomerApi(disableAutoProvisioning);
         var authHeader = await customerApi.Given.AnExistingConsumer("CustomerInterests.Create");
 
         var client = customerApi.CreateClient(authHeader);

--- a/src/LogOtter.CosmosDb.Testing/Configure/ITestCosmosDbBuilder.cs
+++ b/src/LogOtter.CosmosDb.Testing/Configure/ITestCosmosDbBuilder.cs
@@ -1,8 +1,18 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LogOtter.CosmosDb.Testing;
 
 public interface ITestCosmosDbBuilder
 {
     public IServiceCollection Services { get; }
+
+    public ITestCosmosDbBuilder WithPreProvisionedContainer<TDocument>(
+        string containerName,
+        string partitionKeyPath = "/partitionKey",
+        UniqueKeyPolicy? uniqueKeyPolicy = null,
+        int? defaultTimeToLive = -1,
+        IndexingPolicy? indexingPolicy = null,
+        ThroughputProperties? throughputProperties = null
+    );
 }

--- a/src/LogOtter.CosmosDb.Testing/Configure/TestCosmosDbBuilder.cs
+++ b/src/LogOtter.CosmosDb.Testing/Configure/TestCosmosDbBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LogOtter.CosmosDb.Testing;
 
@@ -10,4 +11,34 @@ public class TestCosmosDbBuilder : ITestCosmosDbBuilder
     }
 
     public IServiceCollection Services { get; }
+
+    public ITestCosmosDbBuilder WithPreProvisionedContainer<TDocument>(
+        string containerName,
+        string partitionKeyPath = "/partitionKey",
+        UniqueKeyPolicy? uniqueKeyPolicy = null,
+        int? defaultTimeToLive = -1,
+        IndexingPolicy? indexingPolicy = null,
+        ThroughputProperties? throughputProperties = null
+    )
+    {
+        Services.AddSingleton(sp =>
+        {
+            var cosmosContainerFactory = sp.GetRequiredService<ICosmosContainerFactory>();
+
+            var container = cosmosContainerFactory
+                .CreateContainerIfNotExistsAsync(
+                    containerName,
+                    partitionKeyPath,
+                    uniqueKeyPolicy,
+                    defaultTimeToLive,
+                    indexingPolicy,
+                    throughputProperties
+                )
+                .GetAwaiter()
+                .GetResult();
+
+            return new CosmosContainer<TDocument>(container);
+        });
+        return this;
+    }
 }


### PR DESCRIPTION
After updating to the latest version of LogOtter, I noticed that if I didn't set autoprovisioning in Program.cs, the tests would fail. I thought about just always setting auto provision to true for tests, but that felt like a bit of a footgun and I think it's better to force the consumer to be more specific about what containers they're actually going to create as part of their infra pipeline.

Testing was a bit tricky. Initially I disabled auto provision in the sample so I could implement, but then we still need to test both with and without auto provision in the pipeline, so I've made some of the tests [Theory] and added support to disable auto provisioning. If you can think of a cleaner/nicer way then please suggest :)