### PR TITLE
Fix Cosmos Integration tests

### DIFF
--- a/tests/LogOtter.CosmosDb.ContainerMock.IntegrationTests/Helpers/IntegrationTestsFixture.cs
+++ b/tests/LogOtter.CosmosDb.ContainerMock.IntegrationTests/Helpers/IntegrationTestsFixture.cs
@@ -6,6 +6,7 @@ namespace LogOtter.CosmosDb.ContainerMock.IntegrationTests;
 
 public class IntegrationTestsFixture : IAsyncLifetime
 {
+    private const int CosmosEmulatorPartitionCount = 5;
     private readonly CosmosDbContainer? _container;
     private readonly string _cosmosConnectionString;
     private readonly bool _useTestContainers;
@@ -17,7 +18,7 @@ public class IntegrationTestsFixture : IAsyncLifetime
 
         if (_useTestContainers)
         {
-            _container = new CosmosDbBuilder().WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "2").Build();
+            _container = new CosmosDbBuilder().WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", $"{CosmosEmulatorPartitionCount}").Build();
         }
     }
 

--- a/tests/LogOtter.CosmosDb.ContainerMock.IntegrationTests/Helpers/TestCosmos.cs
+++ b/tests/LogOtter.CosmosDb.ContainerMock.IntegrationTests/Helpers/TestCosmos.cs
@@ -579,7 +579,11 @@ public sealed class TestCosmos : IDisposable
 
     private async Task<ContainerResponse> CreateCosmosContainer(string partitionKeyPath, UniqueKeyPolicy? uniqueKeyPolicy)
     {
-        var dbName = typeof(TestCosmos).Assembly.GetName().Name;
+        // HACK: Since we can't run the CosmosDb in TestContainers on GitHub actions due to a bug in the emulator
+        // and running on real cosmos uses too much of the control plane RU/s, we'll split the tests between different databases.
+        var dbNameIndex = new Random().Next(1, 25);
+        var dbName = typeof(TestCosmos).Assembly.GetName().Name + "_" + dbNameIndex.ToString("00");
+
         var database = (await _client.CreateDatabaseIfNotExistsAsync(dbName, throughput: null)).Database;
 
         var containerProperties = new ContainerProperties


### PR DESCRIPTION
Spread the integration tests across multiple databases in order to spread the control plane operation RU limit.

Also added a retry on the container creation.