### PR TITLE
Add support for specifying the enabled function for event sourcing

### DIFF
--- a/sample/CustomerApi.Tests/CustomerApi.Tests.csproj
+++ b/sample/CustomerApi.Tests/CustomerApi.Tests.csproj
@@ -23,4 +23,5 @@
         </PackageReference>
     </ItemGroup>
 
+
 </Project>

--- a/sample/CustomerApi.Tests/CustomerApi.Tests.csproj
+++ b/sample/CustomerApi.Tests/CustomerApi.Tests.csproj
@@ -23,5 +23,4 @@
         </PackageReference>
     </ItemGroup>
 
-
 </Project>

--- a/sample/CustomerApi.Tests/MovieController/GetMovieTests.cs
+++ b/sample/CustomerApi.Tests/MovieController/GetMovieTests.cs
@@ -1,0 +1,35 @@
+using System.Net;
+using CustomerApi.Uris;
+using FluentAssertions;
+using Xunit;
+
+namespace CustomerApi.Tests.MovieController;
+
+public class GetMovieTests
+{
+    [Fact]
+    public async Task Valid_ReturnsOkWhenUsingEventStream()
+    {
+        using var customerApi = new TestCustomerApi();
+        await customerApi.Given.AnExistingMovie(MovieUri.Parse("/movies/ExistingMovie"), "The Matrix");
+
+        var client = customerApi.CreateClient();
+
+        var response = await client.GetAsync("/movies/ExistingMovie/by-event");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Valid_ReturnsNotFoundWhenUsingSnapshotThatIsNotEnabled()
+    {
+        using var customerApi = new TestCustomerApi();
+        await customerApi.Given.AnExistingMovie(MovieUri.Parse("/movies/ExistingMovie"), "The Matrix");
+
+        var client = customerApi.CreateClient();
+
+        var response = await client.GetAsync("/movies/ExistingMovie/by-snapshot");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
+++ b/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
@@ -1,6 +1,7 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using CustomerApi.Events.Customers;
+using CustomerApi.Events.Movies;
 using CustomerApi.Uris;
 
 namespace CustomerApi.Tests;
@@ -9,11 +10,13 @@ public class GivenSteps
 {
     private readonly ConsumerStore _consumerStore;
     private readonly CustomerStore _customerStore;
+    private readonly MovieStore _movieStore;
 
-    public GivenSteps(CustomerStore customerStore, ConsumerStore consumerStore)
+    public GivenSteps(CustomerStore customerStore, ConsumerStore consumerStore, MovieStore movieStore)
     {
         _customerStore = customerStore;
         _consumerStore = consumerStore;
+        _movieStore = movieStore;
     }
 
     public Task<AuthenticationHeaderValue> AnExistingConsumer(params string[] roles)
@@ -31,6 +34,11 @@ public class GivenSteps
     )
     {
         return await _customerStore.GivenAnExistingCustomer(customerUri, emailAddress, firstName, lastName);
+    }
+
+    public async Task<MovieReadModel> AnExistingMovie(MovieUri movieUri, Discretionary<string> name = default)
+    {
+        return await _movieStore.GivenAnExistingMovie(movieUri, name);
     }
 
     public async Task TheCustomerIsDeleted(CustomerUri customerUri)

--- a/sample/CustomerApi.Tests/TestApi/MovieStore.cs
+++ b/sample/CustomerApi.Tests/TestApi/MovieStore.cs
@@ -1,0 +1,30 @@
+﻿using CustomerApi.Events.Movies;
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+
+// ReSharper disable UnusedMethodReturnValue.Local
+
+namespace CustomerApi.Tests;
+
+public class MovieStore
+{
+    private readonly EventRepository<MovieEvent, MovieReadModel> _movieEventRepository;
+
+    public MovieStore(EventRepository<MovieEvent, MovieReadModel> movieEventRepository)
+    {
+        _movieEventRepository = movieEventRepository;
+    }
+
+    public async Task<MovieReadModel> GivenAnExistingMovie(MovieUri movieUri, Discretionary<string> name)
+    {
+        var movieReadModel = await _movieEventRepository.Get(movieUri.Uri);
+        if (movieReadModel != null)
+        {
+            return movieReadModel;
+        }
+
+        var movieAdded = new MovieAdded(movieUri, name.GetValueOrDefault("Dwayne Dibley in the Duke of Dork"));
+
+        return await _movieEventRepository.ApplyEvents(movieUri.Uri, 0, movieAdded);
+    }
+}

--- a/sample/CustomerApi.Tests/TestApi/TestCustomerApi.cs
+++ b/sample/CustomerApi.Tests/TestApi/TestCustomerApi.cs
@@ -2,6 +2,7 @@
 using System.Net.Http.Headers;
 using CustomerApi.Configuration;
 using CustomerApi.Events.Customers;
+using CustomerApi.Events.Movies;
 using CustomerApi.NonEventSourcedData.CustomerInterests;
 using CustomerApi.Services;
 using LogOtter.CosmosDb;
@@ -67,10 +68,13 @@ public class TestCustomerApi : IDisposable
                     new() { Path = "/LastName", Order = CompositePathSortOrder.Ascending },
                     new() { Path = "/FirstName", Order = CompositePathSortOrder.Ascending }
                 )
-            );
+            )
+            .WithPreProvisionedContainer<MovieEvent>("MovieEvents")
+            .WithPreProvisionedContainer<MovieReadModel>("Movies");
 
         services.AddTransient<ConsumerStore>();
         services.AddTransient<CustomerStore>();
+        services.AddTransient<MovieStore>();
         services.AddTransient<SearchableInterestStore>();
         services.AddTransient<GivenSteps>();
         services.AddTransient<ThenSteps>();

--- a/sample/CustomerApi/Controllers/Movies/MovieController.cs
+++ b/sample/CustomerApi/Controllers/Movies/MovieController.cs
@@ -1,0 +1,51 @@
+using CustomerApi.Events.Movies;
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CustomerApi.Controllers.Movies;
+
+[ApiController]
+[Route("movies/{movieId}")]
+public class MovieController : ControllerBase
+{
+    private readonly EventRepository<MovieEvent, MovieReadModel> _movieEventRepository;
+    private readonly SnapshotRepository<MovieEvent, MovieReadModel> _movieSnapshotRepository;
+
+    public MovieController(
+        EventRepository<MovieEvent, MovieReadModel> movieEventRepository,
+        SnapshotRepository<MovieEvent, MovieReadModel> movieSnapshotRepository
+    )
+    {
+        _movieEventRepository = movieEventRepository;
+        _movieSnapshotRepository = movieSnapshotRepository;
+    }
+
+    [HttpGet("by-event")]
+    public async Task<IActionResult> GetByEvent(string movieId, CancellationToken cancellationToken)
+    {
+        var movieUri = new MovieUri(movieId);
+        var movie = await _movieEventRepository.Get(movieUri.Uri, cancellationToken: cancellationToken);
+
+        if (movie != null)
+        {
+            return Ok(movie);
+        }
+
+        return NotFound();
+    }
+
+    [HttpGet("by-snapshot")]
+    public async Task<IActionResult> GetBySnapshot(string movieId, CancellationToken cancellationToken)
+    {
+        var movieUri = new MovieUri(movieId);
+        var movie = await _movieSnapshotRepository.GetSnapshot(movieUri.Uri, MovieReadModel.StaticPartitionKey, cancellationToken: cancellationToken);
+
+        if (movie != null)
+        {
+            return Ok(movie);
+        }
+
+        return NotFound();
+    }
+}

--- a/sample/CustomerApi/Events/Movies/MovieAdded.cs
+++ b/sample/CustomerApi/Events/Movies/MovieAdded.cs
@@ -1,0 +1,26 @@
+using CustomerApi.Uris;
+
+namespace CustomerApi.Events.Movies;
+
+public class MovieAdded : MovieEvent
+{
+    public string Name { get; }
+
+    public MovieAdded(MovieUri movieUri, string name, DateTimeOffset? timestamp = null)
+        : base(movieUri, timestamp)
+    {
+        Name = name;
+    }
+
+    public override void Apply(MovieReadModel model)
+    {
+        model.MovieUri = MovieUri;
+        model.Name = Name;
+        model.CreatedOn = Timestamp;
+    }
+
+    public override string GetDescription()
+    {
+        return $"Movie {Name} added";
+    }
+}

--- a/sample/CustomerApi/Events/Movies/MovieEvent.cs
+++ b/sample/CustomerApi/Events/Movies/MovieEvent.cs
@@ -1,0 +1,24 @@
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+
+namespace CustomerApi.Events.Movies;
+
+public abstract class MovieEvent : IEvent<MovieReadModel>
+{
+    public MovieUri MovieUri { get; }
+
+    public DateTimeOffset Timestamp { get; }
+
+    public MovieEvent(MovieUri movieUri, DateTimeOffset? timestamp = null)
+    {
+        MovieUri = movieUri;
+        Timestamp = timestamp ?? DateTimeOffset.UtcNow;
+    }
+
+    public string EventStreamId => MovieUri.Uri;
+
+    public abstract void Apply(MovieReadModel model);
+
+    [EventDescription]
+    public abstract string? GetDescription();
+}

--- a/sample/CustomerApi/Events/Movies/MovieReadModel.cs
+++ b/sample/CustomerApi/Events/Movies/MovieReadModel.cs
@@ -1,0 +1,28 @@
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+using Newtonsoft.Json;
+
+namespace CustomerApi.Events.Movies;
+
+#pragma warning disable CS8618
+
+public class MovieReadModel : ISnapshot
+{
+    public const string StaticPartitionKey = "movies";
+
+    public string Name { get; set; }
+
+    public MovieUri MovieUri { get; set; }
+
+    public DateTimeOffset CreatedOn { get; set; }
+
+    [JsonProperty("id")]
+    public string Id { get; init; }
+
+    [JsonProperty("partitionKey")]
+    public string PartitionKey => StaticPartitionKey;
+
+    public DateTimeOffset? DeletedAt { get; set; }
+
+    public int Revision { get; set; }
+}

--- a/sample/CustomerApi/Program.cs
+++ b/sample/CustomerApi/Program.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CustomerApi.Configuration;
 using CustomerApi.Events.Customers;
+using CustomerApi.Events.Movies;
 using CustomerApi.HealthChecks;
 using CustomerApi.NonEventSourcedData.CustomerInterests;
 using CustomerApi.Services;
@@ -61,6 +62,15 @@ services
                 );
 
             c.AddCatchupSubscription<TestCustomerEventCatchupSubscription>("TestCustomerEventCatchupSubscription");
+        }
+    )
+    .AddEventSource<MovieEvent>(
+        "MovieEvents",
+        c =>
+        {
+            c.AddProjection<MovieReadModel>().WithSnapshot("Movies", _ => MovieReadModel.StaticPartitionKey);
+
+            c.SpecifyEnabledFunc(_ => Task.FromResult(false));
         }
     );
 

--- a/src/LogOtter.CosmosDb.EventStore/Configure/EventSourceConfiguration.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/EventSourceConfiguration.cs
@@ -15,6 +15,8 @@ public class EventSourceConfiguration<TBaseEvent>
 
     internal IReadOnlyCollection<ICatchUpSubscriptionMetadata> CatchUpSubscriptions => _catchUpSubscriptions.Values;
 
+    internal Func<IServiceProvider, Task<bool>>? EnabledFunc;
+
     internal EventSourceConfiguration()
     {
         EventTypes = GetEventsOfTypeFromSameAssembly();
@@ -51,6 +53,11 @@ public class EventSourceConfiguration<TBaseEvent>
         where TCatchupSubscriptionHandler : class, ICatchupSubscription<TBaseEvent>
     {
         _catchUpSubscriptions.Add(typeof(TCatchupSubscriptionHandler), new CatchUpSubscriptionMetadata<TCatchupSubscriptionHandler>(projectorName));
+    }
+
+    public void SpecifyEnabledFunc(Func<IServiceProvider, Task<bool>> enabledFunc)
+    {
+        EnabledFunc = enabledFunc;
     }
 
     private static IReadOnlyCollection<Type> GetEventsOfTypeFromSameAssembly()

--- a/src/LogOtter.CosmosDb.EventStore/Configure/EventSourcingBuilder.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/EventSourcingBuilder.cs
@@ -43,7 +43,8 @@ public class EventSourcingBuilder
                     typeof(Event<TBaseEvent>),
                     typeof(EventConverter<TBaseEvent>),
                     specificCatchUpSubscriptionType,
-                    catchUpSubscription.ProjectorName
+                    catchUpSubscription.ProjectorName,
+                    config.EnabledFunc
                 )
             );
         }


### PR DESCRIPTION
Add support for specifying the enabled function for event sourcing.

Specifying this will apply it to all catch up subscriptions, as well as the snapshot processor, for an entire event sourced type.

It's intended usage is for scenarios where you may not want to enable CFPs on every instance of a running service, either for scaling reasons or deployment reasons (for example when using app service deployment slots, once the swap has happened, you probably don't want the old version of the CFP to continue to be run in the non production slot).

I've kept the function the same as we already have for adding catch up subscriptions to containers.