### PR TITLE
Improve event repo tests

### DIFF
--- a/sample/CustomerApi.Tests/MovieController/MovieTests.cs
+++ b/sample/CustomerApi.Tests/MovieController/MovieTests.cs
@@ -43,7 +43,7 @@ public class MovieTests
 
         var client = customerApi.CreateClient();
 
-        var response = await client.GetAsync("/movies/ExistingMovie/by-event");
+        var response = await client.GetAsync("/movies/ExistingMovie/by-hybrid");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }

--- a/sample/CustomerApi/Controllers/Movies/MovieController.cs
+++ b/sample/CustomerApi/Controllers/Movies/MovieController.cs
@@ -38,6 +38,17 @@ public class MovieController : ControllerBase
         return NotFound();
     }
 
+    [HttpGet("{movieId}/history")]
+    public async Task<IActionResult> GetMovieHistory(string movieId, CancellationToken cancellationToken)
+    {
+        var movieUri = new MovieUri(movieId);
+        var movieEvents = await _movieEventRepository.GetEventStream(movieUri.Uri, cancellationToken: cancellationToken);
+
+        var history = movieEvents.Select(e => e.GetDescription() ?? "").ToList();
+
+        return Ok(new MovieHistoryResponse(history));
+    }
+
     [HttpGet("{movieId}/by-snapshot")]
     public async Task<IActionResult> GetBySnapshot(string movieId, CancellationToken cancellationToken)
     {

--- a/sample/CustomerApi/Controllers/Movies/MovieHistoryResponse.cs
+++ b/sample/CustomerApi/Controllers/Movies/MovieHistoryResponse.cs
@@ -1,0 +1,3 @@
+namespace CustomerApi.Controllers.Movies;
+
+public record MovieHistoryResponse(List<string> ChangeDescriptions);


### PR DESCRIPTION
Improve event repo tests by
- Adding missing coverage for a couple of methods (`EventRepository.GetEventStream` and `HybridRepository.GetSnapshotWithCatchupExpensivelyAsync`)
- Make the movie tests more idiomatic by checking the responses in each (this confirms that the different repos are all actually returning the correct data)
- Add swagger/openapi attributes to the `MovieController` to make it a bit more idiomatic, in case anyone uses it to copy from