### PR TITLE
Switch to Windows for running tests so the Cosmos Emulator works

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: windows-latest         # Run on Windows for now so the Cosmos Emulator works
     permissions:
       id-token: write
       contents: read
@@ -36,8 +36,6 @@ jobs:
 
       - name: Test
         run: dotnet test --no-build
-        env:
-          TEST_COSMOS_CONNECTION_STRING: ${{ secrets.TEST_COSMOS_CONNECTION_STRING }}
 
       - name: Test Report
         uses: dorny/test-reporter@v1


### PR DESCRIPTION
Since the real Cosmos is giving lots of errors for exceeding RU/s, I'm going to switch to Windows for running the tests for now