### PR TITLE
Add Azure App Services middleware

### DIFF
--- a/LogOtter.sln
+++ b/LogOtter.sln
@@ -44,6 +44,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomerWorker", "sample\Cu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogOtter.Hub", "src\LogOtter.Hub\LogOtter.Hub.csproj", "{1DEBB304-17E4-4FAE-9772-3B3CC6DF8EEF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LogOtter.Azure.AppServices.RequestMiddleware", "src\LogOtter.Azure.AppServices.RequestMiddleware\LogOtter.Azure.AppServices.RequestMiddleware.csproj", "{A644FC0B-D646-49EB-91A1-0AC9CB719C74}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,10 @@ Global
 		{1DEBB304-17E4-4FAE-9772-3B3CC6DF8EEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1DEBB304-17E4-4FAE-9772-3B3CC6DF8EEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DEBB304-17E4-4FAE-9772-3B3CC6DF8EEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A644FC0B-D646-49EB-91A1-0AC9CB719C74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A644FC0B-D646-49EB-91A1-0AC9CB719C74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A644FC0B-D646-49EB-91A1-0AC9CB719C74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A644FC0B-D646-49EB-91A1-0AC9CB719C74}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5E67A3CB-9089-4AA1-802C-B8CF9DFEEF58} = {3013166D-3A9F-4979-B741-08D4288F5D28}

--- a/sample/CustomerApi/CustomerApi.csproj
+++ b/sample/CustomerApi/CustomerApi.csproj
@@ -18,6 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\..\src\LogOtter.Azure.AppServices.RequestMiddleware\LogOtter.Azure.AppServices.RequestMiddleware.csproj" />
         <ProjectReference Include="..\..\src\LogOtter.CosmosDb.EventStore\LogOtter.CosmosDb.EventStore.csproj" />
         <ProjectReference Include="..\..\src\LogOtter.HttpPatch\LogOtter.HttpPatch.csproj" />
         <ProjectReference Include="..\..\src\LogOtter.JsonHal\LogOtter.JsonHal.csproj" />

--- a/sample/CustomerApi/Program.cs
+++ b/sample/CustomerApi/Program.cs
@@ -5,6 +5,7 @@ using CustomerApi.Events.Movies;
 using CustomerApi.HealthChecks;
 using CustomerApi.NonEventSourcedData.CustomerInterests;
 using CustomerApi.Services;
+using LogOtter.Azure.AppServices.RequestMiddleware;
 using LogOtter.CosmosDb;
 using LogOtter.CosmosDb.EventStore;
 using LogOtter.CosmosDb.EventStore.EventStreamApi;
@@ -84,7 +85,9 @@ if (environment.IsDevelopment())
 
 var app = builder.Build();
 
+app.UseRestoreRawRequestPathMiddleware();
 app.UseCors();
+app.UseAuthorization();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/LogOtter.Azure.AppServices.RequestMiddleware/ConfigureExtensions.cs
+++ b/src/LogOtter.Azure.AppServices.RequestMiddleware/ConfigureExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Builder;
+
+namespace LogOtter.Azure.AppServices.RequestMiddleware;
+
+public static class ConfigureExtensions
+{
+    public static WebApplication UseRestoreRawRequestPathMiddleware(this WebApplication webApplication)
+    {
+        webApplication.UseMiddleware<RestoreRawRequestPathMiddleware>();
+        webApplication.UseRouting();
+
+        return webApplication;
+    }
+}

--- a/src/LogOtter.Azure.AppServices.RequestMiddleware/LogOtter.Azure.AppServices.RequestMiddleware.csproj
+++ b/src/LogOtter.Azure.AppServices.RequestMiddleware/LogOtter.Azure.AppServices.RequestMiddleware.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>LogOtter.Azure.AppServices.RequestMiddleware</RootNamespace>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+</Project>

--- a/src/LogOtter.Azure.AppServices.RequestMiddleware/README.md
+++ b/src/LogOtter.Azure.AppServices.RequestMiddleware/README.md
@@ -1,0 +1,17 @@
+> ⚠️ Warning: LogOtter is still in beta and there are likely to be breaking changes prior to a v1 release. Use at your own peril!
+
+# Azure AppServices RequestMiddleware
+
+Adds middleware for converting the request back to the original request (Azure AppServices
+decode path strings and there is currently no way to disable).
+
+For more information see [dotnet/aspnetcore#40532](https://github.com/dotnet/aspnetcore/issues/40532)
+and [Azure/azure-functions-host#9402](https://github.com/Azure/azure-functions-host/pull/9402#issuecomment-1747347531)
+
+## Examples
+
+Register the middleware
+
+```c#
+app.UseRestoreRawRequestPathMiddleware();
+```

--- a/src/LogOtter.Azure.AppServices.RequestMiddleware/RestoreRawRequestPathMiddleware.cs
+++ b/src/LogOtter.Azure.AppServices.RequestMiddleware/RestoreRawRequestPathMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace LogOtter.Azure.AppServices.RequestMiddleware;
+
+public class RestoreRawRequestPathMiddleware
+{
+    private const string UnencodedUrlHeaderName = "X-Waws-Unencoded-Url";
+
+    private readonly RequestDelegate _next;
+
+    public RestoreRawRequestPathMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(UnencodedUrlHeaderName, out var unencodedUrlValue) && unencodedUrlValue.Any())
+        {
+            context.Request.Path = new PathString(unencodedUrlValue.First());
+        }
+
+        await _next(context);
+    }
+}

--- a/src/LogOtter.Hub/LogOtter.Hub.csproj
+++ b/src/LogOtter.Hub/LogOtter.Hub.csproj
@@ -5,9 +5,11 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\LogOtter.Azure.AppServices.RequestMiddleware\LogOtter.Azure.AppServices.RequestMiddleware.csproj" />
         <ProjectReference Include="..\LogOtter.JsonHal\LogOtter.JsonHal.csproj" />
     </ItemGroup>
 

--- a/src/LogOtter.Hub/Program.cs
+++ b/src/LogOtter.Hub/Program.cs
@@ -1,3 +1,4 @@
+using LogOtter.Azure.AppServices.RequestMiddleware;
 using LogOtter.Hub.Configuration;
 using LogOtter.Hub.Services;
 
@@ -22,6 +23,7 @@ var app = builder.Build();
 
 app.ConfigureReverseProxy(serviceOptions);
 
+app.UseRestoreRawRequestPathMiddleware();
 app.UseCors();
 app.UseFileServer();
 app.UseRouting();


### PR DESCRIPTION
Azure App Services strips encoded path delimiters (`%2F`) before sending the request to the underlying server and this cannot currently be disabled. They do add a header that contains the original URL so this middleware restores back the request URL.

For more information see [dotnet/aspnetcore#40532](https://github.com/dotnet/aspnetcore/issues/40532)
and [Azure/azure-functions-host#9402](https://github.com/Azure/azure-functions-host/pull/9402#issuecomment-1747347531)