### PR TITLE
Fix issue where thrown concurrency exceptions aren't catchable

### DIFF
--- a/src/LogOtter.CosmosDb.EventStore/EventStore/EventStore.cs
+++ b/src/LogOtter.CosmosDb.EventStore/EventStore/EventStore.cs
@@ -34,12 +34,12 @@ public class EventStore<TBaseEvent> : IEventStoreReader
     async Task<IStorageEvent> IEventStoreReader.ReadEventFromStream(string streamId, Guid eventId, CancellationToken cancellationToken) =>
         (await ReadEventFromStream(streamId, eventId, cancellationToken));
 
-    public Task AppendToStream(string streamId, int expectedVersion, params EventData<TBaseEvent>[] events)
+    public async Task AppendToStream(string streamId, int expectedVersion, params EventData<TBaseEvent>[] events)
     {
-        return AppendToStream(streamId, expectedVersion, default, events);
+        await AppendToStream(streamId, expectedVersion, default, events);
     }
 
-    public Task AppendToStream(string streamId, int expectedVersion, CancellationToken cancellationToken, params EventData<TBaseEvent>[] events)
+    public async Task AppendToStream(string streamId, int expectedVersion, CancellationToken cancellationToken, params EventData<TBaseEvent>[] events)
     {
         var storageEvents = new List<StorageEvent<TBaseEvent>>();
         var eventVersion = expectedVersion;
@@ -49,7 +49,7 @@ public class EventStore<TBaseEvent> : IEventStoreReader
             storageEvents.Add(new StorageEvent<TBaseEvent>(streamId, @event, ++eventVersion));
         }
 
-        return AppendToStreamInternal(streamId, storageEvents, cancellationToken);
+        await AppendToStreamInternal(streamId, storageEvents, cancellationToken);
     }
 
     private async Task AppendToStreamInternal(


### PR DESCRIPTION
We encountered an issue where a concurrency exception was thrown, but for some reason wasn't getting caught and handled. These were often accompanied by task cancelled exceptions. Looking into, I think we need the missing awaits and async modifiers I've added in order for the exceptions to properly propagate. See https://stackoverflow.com/questions/21033150/any-difference-between-await-task-run-return-and-return-task-run/21082631#21082631