### PR TITLE
Fix issue where cosmos status code wasn't propagated

### DIFF
--- a/sample/CustomerApi.Tests/CustomerController/CreateCustomerTests.cs
+++ b/sample/CustomerApi.Tests/CustomerController/CreateCustomerTests.cs
@@ -134,4 +134,19 @@ public class CreateCustomerTests(ITestOutputHelper testOutputHelper)
 
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
+
+    [Fact]
+    public async Task Conflict()
+    {
+        using var customerApi = new TestCustomerApi(testOutputHelper);
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Create");
+
+        var client = customerApi.CreateClient(authHeader);
+        var request = new CreateCustomerRequest("bob@bobertson.co.uk", "Bob", "Bobertson");
+        customerApi.Given.CreatingACustomerWillConflict();
+
+        var response = await client.PostAsJsonAsync("/customers", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
 }

--- a/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
+++ b/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
@@ -44,4 +44,9 @@ public class GivenSteps(CustomerStore customerStore, ConsumerStore consumerStore
     {
         await customerStore.GivenTheCustomerIsDeleted(customerUri);
     }
+
+    public void CreatingACustomerWillConflict()
+    {
+        customerStore.GivenCreatingACustomerWillConflict();
+    }
 }

--- a/src/LogOtter.CosmosDb.ContainerMock/TransactionalBatch/TestTransactionalBatch.cs
+++ b/src/LogOtter.CosmosDb.ContainerMock/TransactionalBatch/TestTransactionalBatch.cs
@@ -62,6 +62,11 @@ internal class TestTransactionalBatch(PartitionKey partitionKey, ContainerMock c
             {
                 action(response);
             }
+            catch (CosmosException cEx)
+            {
+                response.SetException(cEx);
+                break;
+            }
             catch (Exception ex)
             {
                 response.SetException(ex);


### PR DESCRIPTION
Originally we were catching and handling `Exception`, causing the `SetException(Exception exception)` overload to be used, which simply sets the status code to InternalServerError: `_statusCode = HttpStatusCode.InternalServerError;`

I've added handling for `CosmosException`, so that the correct status code is surfaced when running tests that use transactional batching. This gives an experience closer to what real Cosmos does.