### PR TITLE
Switch NuGet publish to use Trusted Publishing rather than an API Key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,14 @@ jobs:
       - name: Pack
         run: dotnet pack -p:VersionPrefix="${{ needs.version.outputs.version_3 }}" --version-suffix "${{ needs.version.outputs.version_suffix }}"
 
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish
-        run: dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_APIKEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push "*.nupkg" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
         working-directory: .nupkgs
 
       - name: Upload artifact to action


### PR DESCRIPTION
Change the release workflow to use Trusted Publishing rather than an API Key to publish to NuGet.

See [Trusted Publishing on nuget.org](https://learn.microsoft.com/en-gb/nuget/nuget-org/trusted-publishing) for more information.