### PR TITLE
Add Tombstone compaction

### DIFF
--- a/docs/proposals/stream-compaction-gdpr.md
+++ b/docs/proposals/stream-compaction-gdpr.md
@@ -1,0 +1,185 @@
+# Proposal: Stream Compaction for GDPR Compliance
+
+## Problem
+
+The event sourcing library stores events immutably in Cosmos DB. When a GDPR Article 17 (right to erasure) request arrives, the PII contained in event bodies must be physically removed from the store. The current soft-delete mechanism (`ISnapshot.DeletedAt`) hides projections from read queries but the underlying events — and the PII they contain — remain in the database.
+
+## Proposed Solution: Tombstone-Based Stream Compaction
+
+Replace a stream's full event history with a single "tombstone" event that reproduces a scrubbed version of the current projection state (PII removed), then physically delete the original events.
+
+### How It Works
+
+1. Read all events in the stream and replay them to build the current projection
+2. A consumer-provided compactor creates a tombstone event with PII fields scrubbed
+3. Replace the event at position 1 with the tombstone
+4. Delete events at positions 2 through N
+5. Upsert the snapshot with revision 1
+
+After compaction the stream contains a single event. New events append at position 2 onwards as normal. The tombstone is a regular event — its `Apply` method sets the scrubbed state on a fresh snapshot, so all existing repository and projection machinery continues to work without modification.
+
+### Example
+
+Before compaction:
+
+```
+Stream "customer-123":
+  Event 1: CustomerCreated { Email: "alice@example.com", Name: "Alice Smith" }
+  Event 2: CustomerNameChanged { Name: "Alice Jones" }
+  Event 3: CustomerEmailChanged { Email: "alice.jones@example.com" }
+```
+
+After compaction:
+
+```
+Stream "customer-123":
+  Event 1: CustomerCompacted { Email: "[REDACTED]", Name: "[REDACTED]", CreatedOn: 2025-01-15 }
+```
+
+The consumer controls exactly which fields are scrubbed and which are preserved.
+
+## Design Details
+
+### Why the Tombstone Must Be at Position 1
+
+`EventStore.AppendToStreamInternal` verifies that the previous event exists before creating a new one (optimistic concurrency via a transactional batch read). Event 2 needs event 1 to exist. Placing the tombstone at position 1 means future appends find it and succeed without any changes to the append logic.
+
+### Revision Reset
+
+After compaction the stream contains one event, so `EventRepository.Get` sets `Revision = events.Count = 1`. Any in-flight writes holding a stale revision will receive a `ConcurrencyException` and must retry. This is acceptable for an administrative operation.
+
+### Change Feed Behaviour
+
+Cosmos DB change feed fires for the tombstone replacement (a document update) but does not fire for deletes in default mode. The `SnapshotProjectionCatchupSubscription` receives the tombstone at EventNumber 1. Since the compaction service has already upserted the snapshot at revision 1, the handler's existing check (`snapshot.Revision >= event.EventNumber`) evaluates to `1 >= 1 = true`, skipping the event. No additional change feed handling is required.
+
+### Batch Size Constraint
+
+Cosmos DB transactional batches are limited to 100 operations. The compaction strategy adapts to stream size:
+
+- **Streams with up to 100 events:** A single transactional batch atomically replaces event 1 with the tombstone and deletes events 2 through N.
+- **Streams with more than 100 events:** Delete events in batches of 100 working backwards from the tail, then a final batch replaces event 1 with the tombstone and deletes any remaining events near position 1. Working from the tail means that if the operation is interrupted mid-way, the stream prefix remains valid and the operation can be safely retried.
+
+### Idempotency
+
+If compaction fails partway through (for large streams) and is retried, the retry reads the stream again and only processes events that still exist. Re-replacing the tombstone at position 1 is a no-op in effect. Compacting an already-compacted stream (single event) is also a safe no-op.
+
+### Concurrent Writes During Compaction
+
+If a new event is appended while compaction is deleting events from the tail, the append's concurrency check may fail if the previous event was already deleted, resulting in a `ConcurrencyException`. The caller retries with the correct expected version. This is the same behaviour as any other concurrency conflict and requires no special handling.
+
+## Consumer API
+
+### Interface
+
+Consumers implement `IStreamCompactor<TBaseEvent, TSnapshot>` to define their scrubbing logic:
+
+```csharp
+public interface IStreamCompactor<TBaseEvent, TSnapshot>
+    where TBaseEvent : class, IEvent<TSnapshot>
+    where TSnapshot : class, ISnapshot, new()
+{
+    TBaseEvent CreateTombstoneEvent(TSnapshot currentProjection, string streamId);
+}
+```
+
+### Consumer Implementation Example
+
+```csharp
+public class CustomerStreamCompactor : IStreamCompactor<CustomerEvent, CustomerReadModel>
+{
+    public CustomerEvent CreateTombstoneEvent(CustomerReadModel current, string streamId)
+    {
+        return new CustomerCompacted(
+            current.CustomerUri,
+            emailAddress: "[REDACTED]",
+            firstName: "[REDACTED]",
+            lastName: "[REDACTED]",
+            createdOn: current.CreatedOn
+        );
+    }
+}
+```
+
+The tombstone event class itself is a regular event:
+
+```csharp
+public class CustomerCompacted(
+    CustomerUri customerUri,
+    string emailAddress,
+    string firstName,
+    string lastName,
+    DateTimeOffset createdOn
+) : CustomerEvent(customerUri)
+{
+    public override void Apply(CustomerReadModel model, EventInfo eventInfo)
+    {
+        model.CustomerUri = CustomerUri;
+        model.EmailAddress = emailAddress;
+        model.FirstName = firstName;
+        model.LastName = lastName;
+        model.CreatedOn = createdOn;
+    }
+}
+```
+
+### Configuration
+
+Compaction is opt-in per event source:
+
+```csharp
+services.AddCosmosDb(config => config
+    .AddEventSourcing(es => es
+        .AddEventSource<CustomerEvent>("customer-events", config =>
+        {
+            config.AddProjection<CustomerReadModel>()
+                .WithSnapshot("customer-snapshots", e => CustomerReadModel.StaticPartitionKey);
+
+            config.WithCompaction<CustomerStreamCompactor, CustomerReadModel>();
+        })
+    )
+);
+```
+
+### Usage
+
+```csharp
+public class GdprDeletionService(
+    StreamCompactionService<CustomerEvent, CustomerReadModel> compactionService)
+{
+    public async Task HandleDeletionRequest(string customerId, CancellationToken ct)
+    {
+        await compactionService.CompactStream(customerId, ct);
+    }
+}
+```
+
+## Implementation Scope
+
+### New Types
+
+| Type                                             | Purpose                                         |
+| ------------------------------------------------ | ----------------------------------------------- |
+| `IStreamCompactor<TBaseEvent, TSnapshot>`        | Consumer interface for defining scrubbing logic |
+| `StreamCompactionService<TBaseEvent, TSnapshot>` | Orchestrates the compaction flow                |
+
+### Changes to Existing Types
+
+| Type                                        | Change                                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------ |
+| `EventStore<TBaseEvent>`                    | Add `CompactStream` method (transactional batch replace + delete)              |
+| `SnapshotRepository<TBaseEvent, TSnapshot>` | Add `UpsertSnapshot` method                                                    |
+| `EventSourceConfiguration<TBaseEvent>`      | Add `WithCompaction` builder method                                            |
+| `EventSourcingBuilder`                      | Register compaction services in DI                                             |
+| `TestTransactionalBatch`                    | Implement `DeleteItem` and `ReplaceItem` (currently `NotImplementedException`) |
+| `ContainerMock`                             | Implement `ReplaceItemStreamAsync` (currently `NotImplementedException`)       |
+
+### Test Scenarios
+
+1. Compact single-event stream
+2. Compact multi-event stream (verify original events are deleted)
+3. Append new events after compaction
+4. Compact empty stream (no-op)
+5. Compact large stream (>100 events, multi-batch)
+6. Idempotent re-compaction
+7. Revision resets to 1
+8. `ConcurrencyException` on stale revision after compaction

--- a/docs/proposals/stream-compaction-gdpr.md
+++ b/docs/proposals/stream-compaction-gdpr.md
@@ -12,11 +12,11 @@ Replace a stream's full event history with a single "tombstone" event that repro
 
 1. Read all events in the stream and replay them to build the current projection
 2. A consumer-provided compactor creates a tombstone event with PII fields scrubbed
-3. Replace the event at position 1 with the tombstone
-4. Delete events at positions 2 through N
-5. Upsert the snapshot with revision 1
+3. In one atomic transactional batch, replace event 1 with the tombstone **and** delete up to 99 of the highest-numbered tail events
+4. Delete any remaining tail events in additional 100-op batches
+5. Upsert the snapshot at revision 1
 
-After compaction the stream contains a single event. New events append at position 2 onwards as normal. The tombstone is a regular event — its `Apply` method sets the scrubbed state on a fresh snapshot, so all existing repository and projection machinery continues to work without modification.
+After compaction the stream contains a single event: the tombstone at position 1. The tombstone implements `ICompactionEvent`, which all event-replay paths treat as a hard reset of the projection — they apply it and stop, ignoring anything that follows.
 
 ### Example
 
@@ -40,32 +40,67 @@ The consumer controls exactly which fields are scrubbed and which are preserved.
 
 ## Design Details
 
+### Tombstone-First Ordering
+
+The tombstone is written **before** any events are deleted, in the same atomic batch as the first round of tail deletes. This is the critical invariant that makes crash recovery safe.
+
+If we deleted tail events first and only replaced event 1 in a final batch, a crash mid-way would leave a truncated stream: events 1..K survive but K..N are gone. Retrying would re-derive the projection from the truncated stream and produce a tombstone reflecting **stale state** (the projection at event K, not at event N). Reversing the order guarantees that any post-crash state always has the correctly-derived tombstone at position 1, with leftover events confined to the tail awaiting cleanup.
+
+### `ICompactionEvent` and Read-Path Filtering
+
+Tombstone events implement the marker interface `ICompactionEvent`. Three read paths recognise it:
+
+- `EventRepository.Get` — applies the tombstone, sets `Revision = 1`, and breaks out of the apply loop.
+- `SnapshotRepository.ApplyEventsToSnapshot` — discards the in-progress snapshot, instantiates a fresh one, applies the tombstone, and breaks. This guarantees that a change-feed delivery of the tombstone correctly replaces a stale pre-compaction snapshot regardless of its current revision.
+- `HybridRepository.ApplyNewEvents` — same reset-and-break semantics.
+
+This filtering also protects the read path during the cleanup window. Between Phase A (tombstone-first batch) and Phase B (remaining tail deletes), the stream contains `[tombstone, leftover2, ..., leftoverK]`. Without the filter, applying tombstone + leftovers in sequence would corrupt the projection. With the filter, reads return the correct (tombstone-only) state throughout the cleanup window.
+
 ### Why the Tombstone Must Be at Position 1
 
-`EventStore.AppendToStreamInternal` verifies that the previous event exists before creating a new one (optimistic concurrency via a transactional batch read). Event 2 needs event 1 to exist. Placing the tombstone at position 1 means future appends find it and succeed without any changes to the append logic.
+`EventStore.AppendToStreamInternal` verifies that the previous event exists before creating a new one (optimistic concurrency via a transactional batch read). Event 2 needs event 1 to exist. Placing the tombstone at position 1 means the raw append machinery is unchanged.
 
 ### Revision Reset
 
-After compaction the stream contains one event, so `EventRepository.Get` sets `Revision = events.Count = 1`. Any in-flight writes holding a stale revision will receive a `ConcurrencyException` and must retry. This is acceptable for an administrative operation.
+`EventRepository.Get` returns a snapshot with `Revision = 1` when it encounters a tombstone, regardless of how many leftover events still exist in the stream. The compaction service also upserts the snapshot at revision 1 directly. Any in-flight writes holding a stale revision will receive a `ConcurrencyException` on their next append and must retry.
+
+### Post-Compaction Appends Are Ignored by Projections
+
+This is a deliberate trade-off of the tombstone-first design. The raw event store accepts appends at position 2+ after compaction (the previous-event check passes because event 1 exists), but all projection read paths stop at the tombstone. New events written after compaction land in storage but are invisible to consumers reading the projection.
+
+The reason: with tombstone-first ordering, mid-cleanup the stream looks identical to "compaction complete + user appended a new event" — both produce `[tombstone, eventAt2]`. There's no metadata to distinguish a leftover from a legitimate post-compaction append, so the read path conservatively treats all events after the tombstone as leftovers.
+
+For the GDPR use case this is the right semantic: once a customer's stream is compacted, the customer is logically gone and no further activity should be expected. Streams that need to remain live after compaction are out of scope for this design.
 
 ### Change Feed Behaviour
 
-Cosmos DB change feed fires for the tombstone replacement (a document update) but does not fire for deletes in default mode. The `SnapshotProjectionCatchupSubscription` receives the tombstone at EventNumber 1. Since the compaction service has already upserted the snapshot at revision 1, the handler's existing check (`snapshot.Revision >= event.EventNumber`) evaluates to `1 >= 1 = true`, skipping the event. No additional change feed handling is required.
+Cosmos DB change feed fires for the tombstone replacement (a document update) but does not fire for deletes in default mode. The `SnapshotProjectionCatchupSubscription` receives the tombstone at EventNumber 1.
+
+`SnapshotRepository.ApplyEventsToSnapshot` special-cases `ICompactionEvent`: when one is encountered, it discards the current snapshot (which may still be at the stale pre-compaction revision) and rebuilds it from the tombstone alone. This fires regardless of the existing `Revision >= EventNumber` short-circuit, so the catchup subscription correctly converges the snapshot even if the compaction service crashed before its own upsert.
 
 ### Batch Size Constraint
 
 Cosmos DB transactional batches are limited to 100 operations. The compaction strategy adapts to stream size:
 
 - **Streams with up to 100 events:** A single transactional batch atomically replaces event 1 with the tombstone and deletes events 2 through N.
-- **Streams with more than 100 events:** Delete events in batches of 100 working backwards from the tail, then a final batch replaces event 1 with the tombstone and deletes any remaining events near position 1. Working from the tail means that if the operation is interrupted mid-way, the stream prefix remains valid and the operation can be safely retried.
+- **Streams with more than 100 events:** Phase A — one transactional batch atomically replaces event 1 with the tombstone **and** deletes up to 99 of the highest-numbered tail events. Phase B — remaining tail events are deleted in subsequent 100-op batches.
+
+If the process crashes during Phase B, the stream's first event is already the tombstone, so the read path returns the correct projection immediately. On retry, the compaction service detects the existing tombstone and resumes cleanup without re-deriving the projection.
 
 ### Idempotency
 
-If compaction fails partway through (for large streams) and is retried, the retry reads the stream again and only processes events that still exist. Re-replacing the tombstone at position 1 is a no-op in effect. Compacting an already-compacted stream (single event) is also a safe no-op.
+When `StreamCompactionService.CompactStream` runs against a stream whose first event is already an `ICompactionEvent`, it reuses the existing tombstone verbatim — same `EventId`, `CreatedOn`, and `Metadata` — instead of re-deriving the projection. This is essential after a partial-cleanup crash: re-deriving from a truncated stream would produce a stale tombstone.
+
+Phase A's replace operation is idempotent in effect (the existing tombstone is rewritten with the same content), and Phase B simply deletes whatever leftover events remain. Compacting an already-fully-compacted stream is therefore a safe no-op apart from one redundant document write.
 
 ### Concurrent Writes During Compaction
 
-If a new event is appended while compaction is deleting events from the tail, the append's concurrency check may fail if the previous event was already deleted, resulting in a `ConcurrencyException`. The caller retries with the correct expected version. This is the same behaviour as any other concurrency conflict and requires no special handling.
+If a new event is appended while compaction is running, two outcomes are possible:
+
+- The append's previous-event check finds a now-deleted predecessor → `ConcurrencyException`.
+- The append succeeds and lands at some position > 1. Once compaction completes, that event is in the stream but is treated as a post-compaction leftover by the read path (see *Post-Compaction Appends Are Ignored by Projections*) and is removed by the next compaction run.
+
+Callers are expected to retry on `ConcurrencyException`. Operationally, compaction is a controlled administrative operation; concurrent writes during compaction are not the expected case.
 
 ## Consumer API
 
@@ -100,7 +135,7 @@ public class CustomerStreamCompactor : IStreamCompactor<CustomerEvent, CustomerR
 }
 ```
 
-The tombstone event class itself is a regular event:
+The tombstone event implements both the consumer's event base class and `ICompactionEvent`:
 
 ```csharp
 public class CustomerCompacted(
@@ -109,7 +144,7 @@ public class CustomerCompacted(
     string firstName,
     string lastName,
     DateTimeOffset createdOn
-) : CustomerEvent(customerUri)
+) : CustomerEvent(customerUri), ICompactionEvent
 {
     public override void Apply(CustomerReadModel model, EventInfo eventInfo)
     {
@@ -157,29 +192,35 @@ public class GdprDeletionService(
 
 ### New Types
 
-| Type                                             | Purpose                                         |
-| ------------------------------------------------ | ----------------------------------------------- |
-| `IStreamCompactor<TBaseEvent, TSnapshot>`        | Consumer interface for defining scrubbing logic |
-| `StreamCompactionService<TBaseEvent, TSnapshot>` | Orchestrates the compaction flow                |
+| Type                                             | Purpose                                                                                |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `ICompactionEvent`                               | Marker interface — signals to read paths that this event is a stream-compaction tombstone |
+| `IStreamCompactor<TBaseEvent, TSnapshot>`        | Consumer interface for defining scrubbing logic                                        |
+| `StreamCompactionService<TBaseEvent, TSnapshot>` | Orchestrates the compaction flow                                                       |
 
 ### Changes to Existing Types
 
-| Type                                        | Change                                                                         |
-| ------------------------------------------- | ------------------------------------------------------------------------------ |
-| `EventStore<TBaseEvent>`                    | Add `CompactStream` method (transactional batch replace + delete)              |
-| `SnapshotRepository<TBaseEvent, TSnapshot>` | Add `UpsertSnapshot` method                                                    |
-| `EventSourceConfiguration<TBaseEvent>`      | Add `WithCompaction` builder method                                            |
-| `EventSourcingBuilder`                      | Register compaction services in DI                                             |
-| `TestTransactionalBatch`                    | Implement `DeleteItem` and `ReplaceItem` (currently `NotImplementedException`) |
-| `ContainerMock`                             | Implement `ReplaceItemStreamAsync` (currently `NotImplementedException`)       |
+| Type                                        | Change                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `EventStore<TBaseEvent>`                    | Add `CompactStream` method (tombstone-first atomic batch + tail-cleanup batches)                        |
+| `EventRepository<TBaseEvent, TSnapshot>`    | `Get` stops applying at the first `ICompactionEvent` and forces `Revision = 1`                          |
+| `SnapshotRepository<TBaseEvent, TSnapshot>` | Add `UpsertSnapshot`; `ApplyEventsToSnapshot` resets the snapshot when it encounters an `ICompactionEvent` |
+| `HybridRepository<TBaseEvent, TSnapshot>`   | `ApplyNewEvents` stops applying at the first `ICompactionEvent`                                         |
+| `EventSourceConfiguration<TBaseEvent>`      | Add `WithCompaction` builder method                                                                     |
+| `EventSourcingBuilder`                      | Register compaction services in DI                                                                      |
+| `TestTransactionalBatch`                    | Implement `DeleteItem` and `ReplaceItem` (previously `NotImplementedException`)                         |
+| `ContainerMock`                             | Implement `ReplaceItemStreamAsync` (previously `NotImplementedException`)                               |
 
 ### Test Scenarios
 
 1. Compact single-event stream
 2. Compact multi-event stream (verify original events are deleted)
-3. Append new events after compaction
-4. Compact empty stream (no-op)
-5. Compact large stream (>100 events, multi-batch)
-6. Idempotent re-compaction
-7. Revision resets to 1
-8. `ConcurrencyException` on stale revision after compaction
+3. Compact empty stream (no-op)
+4. Compact large stream (>100 events, multi-batch)
+5. Idempotent re-compaction
+6. Revision resets to 1
+7. `ConcurrencyException` on stale revision after compaction
+8. Compaction upserts snapshot at revision 1
+9. Retry after partial cleanup reuses the original tombstone (does not re-derive from a truncated stream)
+10. Leftovers after the tombstone do not corrupt projections
+11. Post-compaction appends are accepted by the raw store but ignored by projections

--- a/sample/CustomerApi.Tests/CustomerController/CompactCustomerTests.cs
+++ b/sample/CustomerApi.Tests/CustomerController/CompactCustomerTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using CustomerApi.Events.Customers;
+using CustomerApi.Uris;
+using Shouldly;
+using Xunit;
+
+namespace CustomerApi.Tests.CustomerController;
+
+public class CompactCustomerTests
+{
+    [Fact]
+    public async Task NoExisting_ReturnsNotFound()
+    {
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        var client = customerApi.CreateClient(authHeader);
+
+        var response = await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Existing_ReturnsNoContent()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        await customerApi.Given.AnExistingCustomer(customerUri);
+        var client = customerApi.CreateClient(authHeader);
+
+        var response = await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Existing_PiiIsScrubbedFromReadModel()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        await customerApi.Given.AnExistingCustomer(customerUri, emailAddress: "bob@bobertson.co.uk", firstName: "Bob", lastName: "Bobertson");
+        var client = customerApi.CreateClient(authHeader);
+
+        await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        await customerApi.Then.TheCustomerShouldMatch(
+            customerUri,
+            c => c.EmailAddress.ShouldBe(CustomerStreamCompactor.RedactedValue),
+            c => c.FirstName.ShouldBe(CustomerStreamCompactor.RedactedValue),
+            c => c.LastName.ShouldBe(CustomerStreamCompactor.RedactedValue)
+        );
+    }
+
+    [Fact]
+    public async Task Existing_OriginalEventsAreDeleted()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        await customerApi.Given.AnExistingCustomer(customerUri, emailAddress: "bob@bobertson.co.uk", firstName: "Bob", lastName: "Bobertson");
+        await customerApi.Given.TheCustomerNameIsChanged(customerUri, "Bobby", "Bobertson");
+        var client = customerApi.CreateClient(authHeader);
+
+        await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        await customerApi.Then.TheCustomerStreamShouldOnlyContainTombstone(customerUri);
+    }
+
+    [Fact]
+    public async Task Existing_CreatedOnIsPreserved()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        var original = await customerApi.Given.AnExistingCustomer(customerUri, emailAddress: "bob@bobertson.co.uk", firstName: "Bob", lastName: "Bobertson");
+        var client = customerApi.CreateClient(authHeader);
+
+        await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        await customerApi.Then.TheCustomerShouldMatch(customerUri, c => c.CreatedOn.ShouldBe(original.CreatedOn));
+    }
+
+    [Fact]
+    public async Task ExistingDeleted_ReturnsNoContent()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        await customerApi.Given.AnExistingCustomer(customerUri);
+        await customerApi.Given.TheCustomerIsDeleted(customerUri);
+        var client = customerApi.CreateClient(authHeader);
+
+        var response = await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task Idempotent_RecompactingIsSafe()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
+        await customerApi.Given.AnExistingCustomer(customerUri, emailAddress: "bob@bobertson.co.uk", firstName: "Bob", lastName: "Bobertson");
+        var client = customerApi.CreateClient(authHeader);
+
+        await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+        var response = await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+        await customerApi.Then.TheCustomerStreamShouldOnlyContainTombstone(customerUri);
+    }
+
+    [Fact]
+    public async Task Unauthorized()
+    {
+        using var customerApi = new TestCustomerApi();
+        var client = customerApi.CreateClient();
+
+        var response = await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Forbidden()
+    {
+        using var customerApi = new TestCustomerApi();
+        var authHeader = await customerApi.Given.AnExistingConsumer("Customers.InvalidRole");
+        var client = customerApi.CreateClient(authHeader);
+
+        var response = await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.Forbidden);
+    }
+}

--- a/sample/CustomerApi.Tests/CustomerController/CompactCustomerTests.cs
+++ b/sample/CustomerApi.Tests/CustomerController/CompactCustomerTests.cs
@@ -78,7 +78,12 @@ public class CompactCustomerTests
 
         using var customerApi = new TestCustomerApi();
         var authHeader = await customerApi.Given.AnExistingConsumer("Customers.Compact");
-        var original = await customerApi.Given.AnExistingCustomer(customerUri, emailAddress: "bob@bobertson.co.uk", firstName: "Bob", lastName: "Bobertson");
+        var original = await customerApi.Given.AnExistingCustomer(
+            customerUri,
+            emailAddress: "bob@bobertson.co.uk",
+            firstName: "Bob",
+            lastName: "Bobertson"
+        );
         var client = customerApi.CreateClient(authHeader);
 
         await client.PostAsync("/customers/CustomerId/compact", content: null, TestContext.Current.CancellationToken);

--- a/sample/CustomerApi.Tests/CustomerController/CompactionRequestedTests.cs
+++ b/sample/CustomerApi.Tests/CustomerController/CompactionRequestedTests.cs
@@ -1,0 +1,29 @@
+using CustomerApi.Events.Customers;
+using CustomerApi.Uris;
+using Shouldly;
+using Xunit;
+
+namespace CustomerApi.Tests.CustomerController;
+
+public class CompactionRequestedTests
+{
+    [Fact]
+    public async Task AppendingCompactionRequestedEvent_TriggersCompactionViaChangeFeed()
+    {
+        var customerUri = CustomerUri.Parse("/customers/CustomerId");
+
+        using var customerApi = new TestCustomerApi();
+        await customerApi.Given.AnExistingCustomer(customerUri, emailAddress: "bob@bobertson.co.uk", firstName: "Bob", lastName: "Bobertson");
+        await customerApi.Given.TheCustomerNameIsChanged(customerUri, "Bobby", "Bobertson");
+
+        await customerApi.Given.CompactionIsRequested(customerUri);
+
+        await customerApi.Then.TheCustomerStreamShouldOnlyContainTombstone(customerUri);
+        await customerApi.Then.TheCustomerShouldMatch(
+            customerUri,
+            c => c.EmailAddress.ShouldBe(CustomerStreamCompactor.RedactedValue),
+            c => c.FirstName.ShouldBe(CustomerStreamCompactor.RedactedValue),
+            c => c.LastName.ShouldBe(CustomerStreamCompactor.RedactedValue)
+        );
+    }
+}

--- a/sample/CustomerApi.Tests/TestApi/CustomerStore.cs
+++ b/sample/CustomerApi.Tests/TestApi/CustomerStore.cs
@@ -66,6 +66,19 @@ public class CustomerStore(
         await ApplyEvents(customerDeleted);
     }
 
+    public async Task GivenAnExistingCustomerNameIsChanged(CustomerUri customerUri, string newFirstName, string newLastName)
+    {
+        var customer = await customerEventRepository.Get(customerUri.Uri);
+        var nameChanged = new CustomerNameChanged(
+            customerUri,
+            customer!.FirstName,
+            newFirstName,
+            customer.LastName,
+            newLastName
+        );
+        await customerEventRepository.ApplyEvents(customerUri.Uri, customer.Revision, nameChanged);
+    }
+
     public async Task ThenTheCustomerShouldBeDeleted(CustomerUri customerUri)
     {
         var customerReadModel = await customerSnapshotRepository.GetSnapshot(customerUri.Uri, CustomerReadModel.StaticPartitionKey);
@@ -89,6 +102,14 @@ public class CustomerStore(
         var revision = customer?.Revision ?? 0;
 
         return await customerEventRepository.ApplyEvents(customerUri.Uri, revision, events);
+    }
+
+    public async Task ThenTheCustomerStreamShouldOnlyContainTombstone(CustomerUri customerUri)
+    {
+        var events = await customerEventRepository.GetEventStream(customerUri.Uri);
+
+        events.Count.ShouldBe(1, "The stream should have been compacted to a single tombstone event");
+        events.Single().ShouldBeOfType<CustomerCompacted>();
     }
 
     public async Task ThenTheCustomerShouldMatch(CustomerUri customerUri, params Action<CustomerReadModel>[] conditions)

--- a/sample/CustomerApi.Tests/TestApi/CustomerStore.cs
+++ b/sample/CustomerApi.Tests/TestApi/CustomerStore.cs
@@ -69,13 +69,7 @@ public class CustomerStore(
     public async Task GivenAnExistingCustomerNameIsChanged(CustomerUri customerUri, string newFirstName, string newLastName)
     {
         var customer = await customerEventRepository.Get(customerUri.Uri);
-        var nameChanged = new CustomerNameChanged(
-            customerUri,
-            customer!.FirstName,
-            newFirstName,
-            customer.LastName,
-            newLastName
-        );
+        var nameChanged = new CustomerNameChanged(customerUri, customer!.FirstName, newFirstName, customer.LastName, newLastName);
         await customerEventRepository.ApplyEvents(customerUri.Uri, customer.Revision, nameChanged);
     }
 

--- a/sample/CustomerApi.Tests/TestApi/CustomerStore.cs
+++ b/sample/CustomerApi.Tests/TestApi/CustomerStore.cs
@@ -73,6 +73,13 @@ public class CustomerStore(
         await customerEventRepository.ApplyEvents(customerUri.Uri, customer.Revision, nameChanged);
     }
 
+    public async Task GivenCompactionIsRequested(CustomerUri customerUri)
+    {
+        var customer = await customerEventRepository.Get(customerUri.Uri);
+        var compactionRequested = new CustomerCompactionRequested(customerUri);
+        await customerEventRepository.ApplyEvents(customerUri.Uri, customer!.Revision, compactionRequested);
+    }
+
     public async Task ThenTheCustomerShouldBeDeleted(CustomerUri customerUri)
     {
         var customerReadModel = await customerSnapshotRepository.GetSnapshot(customerUri.Uri, CustomerReadModel.StaticPartitionKey);

--- a/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
+++ b/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
@@ -50,6 +50,11 @@ public class GivenSteps(CustomerStore customerStore, ConsumerStore consumerStore
         await customerStore.GivenAnExistingCustomerNameIsChanged(customerUri, newFirstName, newLastName);
     }
 
+    public async Task CompactionIsRequested(CustomerUri customerUri)
+    {
+        await customerStore.GivenCompactionIsRequested(customerUri);
+    }
+
     public void CreatingACustomerWillConflict()
     {
         customerStore.GivenCreatingACustomerWillConflict();

--- a/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
+++ b/sample/CustomerApi.Tests/TestApi/GivenSteps.cs
@@ -45,6 +45,11 @@ public class GivenSteps(CustomerStore customerStore, ConsumerStore consumerStore
         await customerStore.GivenTheCustomerIsDeleted(customerUri);
     }
 
+    public async Task TheCustomerNameIsChanged(CustomerUri customerUri, string newFirstName, string newLastName)
+    {
+        await customerStore.GivenAnExistingCustomerNameIsChanged(customerUri, newFirstName, newLastName);
+    }
+
     public void CreatingACustomerWillConflict()
     {
         customerStore.GivenCreatingACustomerWillConflict();

--- a/sample/CustomerApi.Tests/TestApi/ThenSteps.cs
+++ b/sample/CustomerApi.Tests/TestApi/ThenSteps.cs
@@ -18,6 +18,11 @@ public class ThenSteps(CustomerStore customerStore, SearchableInterestStore sear
         await customerStore.ThenTheCustomerShouldMatch(customerUri, conditions);
     }
 
+    public async Task TheCustomerStreamShouldOnlyContainTombstone(CustomerUri customerUri)
+    {
+        await customerStore.ThenTheCustomerStreamShouldOnlyContainTombstone(customerUri);
+    }
+
     public async Task TheMovieShouldMatch(MovieUri movieUri, params Action<Movie>[] conditions)
     {
         await customerStore.ThenTheMovieShouldMatch(movieUri, conditions);

--- a/sample/CustomerApi/Controllers/Customers/Compact/CompactCustomerController.cs
+++ b/sample/CustomerApi/Controllers/Customers/Compact/CompactCustomerController.cs
@@ -1,0 +1,40 @@
+using CustomerApi.Events.Customers;
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CustomerApi.Controllers.Customers.Compact;
+
+[ApiController]
+[Route("customers")]
+[Authorize(Roles = "Customers.Compact")]
+public class CompactCustomerController(
+    EventRepository<CustomerEvent, CustomerReadModel> customerEventRepository,
+    StreamCompactionService<CustomerEvent, CustomerReadModel> compactionService
+) : ControllerBase
+{
+    [HttpPost("{id}/compact")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Compact([FromRoute] string id, CancellationToken cancellationToken)
+    {
+        if (!Id.TryParse(id, out var customerId))
+        {
+            return NotFound();
+        }
+
+        var customerUri = new CustomerUri(customerId);
+
+        var customerReadModel = await customerEventRepository.Get(customerUri.Uri, includeDeleted: true, cancellationToken: cancellationToken);
+
+        if (customerReadModel == null)
+        {
+            return NotFound();
+        }
+
+        await compactionService.CompactStream(customerUri.Uri, cancellationToken);
+
+        return NoContent();
+    }
+}

--- a/sample/CustomerApi/Events/Customers/CustomerCompacted.cs
+++ b/sample/CustomerApi/Events/Customers/CustomerCompacted.cs
@@ -1,0 +1,37 @@
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+
+namespace CustomerApi.Events.Customers;
+
+public class CustomerCompacted(
+    CustomerUri customerUri,
+    string emailAddress,
+    string firstName,
+    string lastName,
+    DateTimeOffset createdOn,
+    DateTimeOffset? timestamp = null
+) : CustomerEvent(customerUri, timestamp), ICompactionEvent
+{
+    public string EmailAddress { get; } = emailAddress;
+
+    public string FirstName { get; } = firstName;
+
+    public string LastName { get; } = lastName;
+
+    public DateTimeOffset CreatedOn { get; } = createdOn;
+
+    public override void Apply(CustomerReadModel model, EventInfo eventInfo)
+    {
+        model.CustomerUri = CustomerUri;
+        model.EmailAddress = EmailAddress;
+        model.EmailAddresses = new List<string>();
+        model.FirstName = FirstName;
+        model.LastName = LastName;
+        model.CreatedOn = CreatedOn;
+    }
+
+    public override string GetDescription()
+    {
+        return "Compacted (PII scrubbed)";
+    }
+}

--- a/sample/CustomerApi/Events/Customers/CustomerCompactionRequested.cs
+++ b/sample/CustomerApi/Events/Customers/CustomerCompactionRequested.cs
@@ -4,7 +4,8 @@ using LogOtter.CosmosDb.EventStore;
 namespace CustomerApi.Events.Customers;
 
 public class CustomerCompactionRequested(CustomerUri customerUri, DateTimeOffset? timestamp = null)
-    : CustomerEvent(customerUri, timestamp), ICompactionRequestedEvent<CustomerReadModel>
+    : CustomerEvent(customerUri, timestamp),
+        ICompactionRequestedEvent<CustomerReadModel>
 {
     public override void Apply(CustomerReadModel model, EventInfo eventInfo)
     {

--- a/sample/CustomerApi/Events/Customers/CustomerCompactionRequested.cs
+++ b/sample/CustomerApi/Events/Customers/CustomerCompactionRequested.cs
@@ -1,0 +1,18 @@
+using CustomerApi.Uris;
+using LogOtter.CosmosDb.EventStore;
+
+namespace CustomerApi.Events.Customers;
+
+public class CustomerCompactionRequested(CustomerUri customerUri, DateTimeOffset? timestamp = null)
+    : CustomerEvent(customerUri, timestamp), ICompactionRequestedEvent<CustomerReadModel>
+{
+    public override void Apply(CustomerReadModel model, EventInfo eventInfo)
+    {
+        // No projection change — this event exists solely as a signal to the compaction change feed processor.
+    }
+
+    public override string GetDescription()
+    {
+        return "Compaction requested";
+    }
+}

--- a/sample/CustomerApi/Events/Customers/CustomerStreamCompactor.cs
+++ b/sample/CustomerApi/Events/Customers/CustomerStreamCompactor.cs
@@ -8,12 +8,6 @@ public class CustomerStreamCompactor : IStreamCompactor<CustomerEvent, CustomerR
 
     public CustomerEvent CreateTombstoneEvent(CustomerReadModel currentProjection, string streamId)
     {
-        return new CustomerCompacted(
-            currentProjection.CustomerUri,
-            RedactedValue,
-            RedactedValue,
-            RedactedValue,
-            currentProjection.CreatedOn
-        );
+        return new CustomerCompacted(currentProjection.CustomerUri, RedactedValue, RedactedValue, RedactedValue, currentProjection.CreatedOn);
     }
 }

--- a/sample/CustomerApi/Events/Customers/CustomerStreamCompactor.cs
+++ b/sample/CustomerApi/Events/Customers/CustomerStreamCompactor.cs
@@ -1,0 +1,19 @@
+using LogOtter.CosmosDb.EventStore;
+
+namespace CustomerApi.Events.Customers;
+
+public class CustomerStreamCompactor : IStreamCompactor<CustomerEvent, CustomerReadModel>
+{
+    public const string RedactedValue = "[REDACTED]";
+
+    public CustomerEvent CreateTombstoneEvent(CustomerReadModel currentProjection, string streamId)
+    {
+        return new CustomerCompacted(
+            currentProjection.CustomerUri,
+            RedactedValue,
+            RedactedValue,
+            RedactedValue,
+            currentProjection.CreatedOn
+        );
+    }
+}

--- a/sample/CustomerApi/Program.cs
+++ b/sample/CustomerApi/Program.cs
@@ -63,6 +63,8 @@ services
                 );
 
             c.AddCatchupSubscription<TestCustomerEventCatchupSubscription>("TestCustomerEventCatchupSubscription");
+
+            c.WithCompaction<CustomerStreamCompactor, CustomerReadModel>();
         }
     )
     .AddEventSource<MovieEvent>(

--- a/src/LogOtter.CosmosDb.ContainerMock/ContainerMock.cs
+++ b/src/LogOtter.CosmosDb.ContainerMock/ContainerMock.cs
@@ -665,7 +665,6 @@ public class ContainerMock : Container
         throw new NotImplementedException();
     }
 
-
     public override Task<ResponseMessage> ReadManyItemsStreamAsync(
         IReadOnlyList<(string id, PartitionKey partitionKey)> items,
         ReadManyRequestOptions? readManyRequestOptions = null,

--- a/src/LogOtter.CosmosDb.ContainerMock/ContainerMock.cs
+++ b/src/LogOtter.CosmosDb.ContainerMock/ContainerMock.cs
@@ -308,6 +308,43 @@ public class ContainerMock : Container
         return ReplaceItemAsync(item, id, partitionKey, requestOptions, DataChangeMode.Auto, cancellationToken);
     }
 
+    public override Task<ResponseMessage> ReplaceItemStreamAsync(
+        Stream streamPayload,
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return ReplaceItemStreamAsync(streamPayload, id, partitionKey, requestOptions, DataChangeMode.Auto, cancellationToken);
+    }
+
+    internal async Task<ResponseMessage> ReplaceItemStreamAsync(
+        Stream streamPayload,
+        string id,
+        PartitionKey partitionKey,
+        ItemRequestOptions? requestOptions = null,
+        DataChangeMode dataChangeMode = DataChangeMode.Auto,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ThrowNextExceptionIfPresent(new InvocationInformation(nameof(ReplaceItemStreamAsync)));
+
+        streamPayload.Position = 0;
+        var streamReader = new StreamReader(streamPayload);
+        var json = await streamReader.ReadToEndAsync(cancellationToken);
+
+        try
+        {
+            var response = await _containerData.ReplaceItem(id, json, partitionKey, dataChangeMode, requestOptions, cancellationToken);
+            return ToCosmosResponseMessage(response, streamPayload);
+        }
+        catch (ContainerMockException ex)
+        {
+            return new ResponseMessage(ex.StatusCode);
+        }
+    }
+
     internal async Task<ItemResponse<T>> ReplaceItemAsync<T>(
         T item,
         string id,
@@ -628,16 +665,6 @@ public class ContainerMock : Container
         throw new NotImplementedException();
     }
 
-    public override Task<ResponseMessage> ReplaceItemStreamAsync(
-        Stream streamPayload,
-        string id,
-        PartitionKey partitionKey,
-        ItemRequestOptions? requestOptions = null,
-        CancellationToken cancellationToken = default
-    )
-    {
-        throw new NotImplementedException();
-    }
 
     public override Task<ResponseMessage> ReadManyItemsStreamAsync(
         IReadOnlyList<(string id, PartitionKey partitionKey)> items,

--- a/src/LogOtter.CosmosDb.ContainerMock/TransactionalBatch/TestTransactionalBatch.cs
+++ b/src/LogOtter.CosmosDb.ContainerMock/TransactionalBatch/TestTransactionalBatch.cs
@@ -117,6 +117,15 @@ internal class TestTransactionalBatch(PartitionKey partitionKey, ContainerMock c
         throw new NotImplementedException();
     }
 
+    public override Microsoft.Azure.Cosmos.TransactionalBatch ReplaceItemStream(
+        string id,
+        Stream streamPayload,
+        TransactionalBatchItemRequestOptions? requestOptions = null
+    )
+    {
+        throw new NotImplementedException();
+    }
+
     public override Microsoft.Azure.Cosmos.TransactionalBatch UpsertItem<T>(T item, TransactionalBatchItemRequestOptions? requestOptions = null)
     {
         throw new NotImplementedException();
@@ -136,21 +145,40 @@ internal class TestTransactionalBatch(PartitionKey partitionKey, ContainerMock c
         TransactionalBatchItemRequestOptions? requestOptions = null
     )
     {
-        throw new NotImplementedException();
-    }
+        var itemRequestOptions = CreateItemRequestOptions(requestOptions);
 
-    public override Microsoft.Azure.Cosmos.TransactionalBatch ReplaceItemStream(
-        string id,
-        Stream streamPayload,
-        TransactionalBatchItemRequestOptions? requestOptions = null
-    )
-    {
-        throw new NotImplementedException();
+        _actions.Enqueue(response =>
+        {
+            var bytes = Encoding.UTF8.GetBytes(serializationHelper.SerializeObject(item));
+
+            using var ms = new MemoryStream(bytes);
+
+            var itemResponse = containerMock
+                .ReplaceItemStreamAsync(ms, id, partitionKey, itemRequestOptions, DataChangeMode.Manual)
+                .GetAwaiter()
+                .GetResult();
+
+            response.AddResult(itemResponse, item);
+        });
+
+        return this;
     }
 
     public override Microsoft.Azure.Cosmos.TransactionalBatch DeleteItem(string id, TransactionalBatchItemRequestOptions? requestOptions = null)
     {
-        throw new NotImplementedException();
+        var itemRequestOptions = CreateItemRequestOptions(requestOptions);
+
+        _actions.Enqueue(response =>
+        {
+            var itemResponse = containerMock
+                .DeleteItemStreamAsync(id, partitionKey, itemRequestOptions, DataChangeMode.Manual)
+                .GetAwaiter()
+                .GetResult();
+
+            response.AddResult(itemResponse);
+        });
+
+        return this;
     }
 
     public override Microsoft.Azure.Cosmos.TransactionalBatch PatchItem(

--- a/src/LogOtter.CosmosDb.EventStore/CatchUpSubscriptions/CompactionChangeFeedProcessor.cs
+++ b/src/LogOtter.CosmosDb.EventStore/CatchUpSubscriptions/CompactionChangeFeedProcessor.cs
@@ -1,0 +1,18 @@
+namespace LogOtter.CosmosDb.EventStore;
+
+public class CompactionChangeFeedProcessor<TBaseEvent, TSnapshot>(StreamCompactionService<TBaseEvent, TSnapshot> compactionService)
+    : IChangeFeedProcessorChangeHandler<Event<TBaseEvent>>
+    where TBaseEvent : class, IEvent<TSnapshot>
+    where TSnapshot : class, ISnapshot, new()
+{
+    public async Task ProcessChanges(IReadOnlyCollection<Event<TBaseEvent>> changes, CancellationToken cancellationToken)
+    {
+        foreach (var change in changes)
+        {
+            if (change.Body is ICompactionRequestedEvent<TSnapshot> body)
+            {
+                await compactionService.CompactStream(body.EventStreamId, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/LogOtter.CosmosDb.EventStore/Configure/CompactionMetadata.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/CompactionMetadata.cs
@@ -1,0 +1,3 @@
+namespace LogOtter.CosmosDb.EventStore;
+
+internal record CompactionMetadata(Type CompactorType, Type SnapshotType);

--- a/src/LogOtter.CosmosDb.EventStore/Configure/EventSourceConfiguration.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/EventSourceConfiguration.cs
@@ -36,10 +36,7 @@ public class EventSourceConfiguration<TBaseEvent>
         var compactorInterface = typeof(IStreamCompactor<,>).MakeGenericType(typeof(TBaseEvent), typeof(TSnapshot));
         if (!compactorInterface.IsAssignableFrom(typeof(TCompactor)))
         {
-            throw new ArgumentException(
-                $"{typeof(TCompactor).Name} must implement {compactorInterface.Name}",
-                nameof(TCompactor)
-            );
+            throw new ArgumentException($"{typeof(TCompactor).Name} must implement {compactorInterface.Name}", nameof(TCompactor));
         }
 
         _compactions.Add(new CompactionMetadata(typeof(TCompactor), typeof(TSnapshot)));

--- a/src/LogOtter.CosmosDb.EventStore/Configure/EventSourceConfiguration.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/EventSourceConfiguration.cs
@@ -9,11 +9,15 @@ public class EventSourceConfiguration<TBaseEvent>
 
     private readonly Dictionary<Type, ICatchUpSubscriptionMetadata> _catchUpSubscriptions;
 
+    private readonly List<CompactionMetadata> _compactions;
+
     internal IReadOnlyCollection<Type> EventTypes { get; private set; }
 
     internal IReadOnlyCollection<IProjectionMetadata<TBaseEvent>> Projections => _projections.Values;
 
     internal IReadOnlyCollection<ICatchUpSubscriptionMetadata> CatchUpSubscriptions => _catchUpSubscriptions.Values;
+
+    internal IReadOnlyCollection<CompactionMetadata> Compactions => _compactions;
 
     internal Func<IServiceProvider, Task<bool>>? EnabledFunc;
 
@@ -22,6 +26,23 @@ public class EventSourceConfiguration<TBaseEvent>
         EventTypes = GetEventsOfTypeFromSameAssembly();
         _projections = new Dictionary<Type, IProjectionMetadata<TBaseEvent>>();
         _catchUpSubscriptions = new Dictionary<Type, ICatchUpSubscriptionMetadata>();
+        _compactions = new List<CompactionMetadata>();
+    }
+
+    public void WithCompaction<TCompactor, TSnapshot>()
+        where TCompactor : class
+        where TSnapshot : class, ISnapshot, new()
+    {
+        var compactorInterface = typeof(IStreamCompactor<,>).MakeGenericType(typeof(TBaseEvent), typeof(TSnapshot));
+        if (!compactorInterface.IsAssignableFrom(typeof(TCompactor)))
+        {
+            throw new ArgumentException(
+                $"{typeof(TCompactor).Name} must implement {compactorInterface.Name}",
+                nameof(TCompactor)
+            );
+        }
+
+        _compactions.Add(new CompactionMetadata(typeof(TCompactor), typeof(TSnapshot)));
     }
 
     public ProjectionBuilder<TBaseEvent, TProjection> AddProjection<TProjection>()

--- a/src/LogOtter.CosmosDb.EventStore/Configure/EventSourcingBuilder.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/EventSourcingBuilder.cs
@@ -95,6 +95,29 @@ public class EventSourcingBuilder
             }
         );
 
+        var streamCompactor = typeof(IStreamCompactor<,>);
+        var streamCompactionService = typeof(StreamCompactionService<,>);
+        var streamCompactionChangeFeedProcessor = typeof(CompactionChangeFeedProcessor<,>);
+        foreach (var compaction in config.Compactions)
+        {
+            Services.AddSingleton(streamCompactor.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType), compaction.CompactorType);
+            Services.AddSingleton(streamCompactionService.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType));
+
+            var specificCompactionProcessor = streamCompactionChangeFeedProcessor.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType);
+            Services.AddSingleton(specificCompactionProcessor);
+            changeFeedProcessorsMetadata.Add(
+                new ChangeFeedProcessorMetadata(
+                    typeof(CosmosDbStorageEvent),
+                    typeof(TBaseEvent),
+                    typeof(Event<TBaseEvent>),
+                    typeof(EventConverter<TBaseEvent>),
+                    specificCompactionProcessor,
+                    $"{compaction.SnapshotType.Name}_Compactor",
+                    config.EnabledFunc
+                )
+            );
+        }
+
         _cosmosDbBuilder.AddContainer(typeof(TBaseEvent), containerName, autoProvisionMetadata, changeFeedProcessorsMetadata);
 
         Services.AddSingleton(sp =>
@@ -104,15 +127,6 @@ public class EventSourcingBuilder
 
             return new EventStore<TBaseEvent>(cosmosContainer.Container, feedIteratorFactory, simpleSerializationTypeMap);
         });
-
-        var streamCompactionService = typeof(StreamCompactionService<,>);
-        var streamCompactor = typeof(IStreamCompactor<,>);
-        foreach (var compaction in config.Compactions)
-        {
-            var compactorInterface = streamCompactor.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType);
-            Services.AddSingleton(compactorInterface, compaction.CompactorType);
-            Services.AddSingleton(streamCompactionService.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType));
-        }
 
         return this;
     }

--- a/src/LogOtter.CosmosDb.EventStore/Configure/EventSourcingBuilder.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Configure/EventSourcingBuilder.cs
@@ -105,6 +105,15 @@ public class EventSourcingBuilder
             return new EventStore<TBaseEvent>(cosmosContainer.Container, feedIteratorFactory, simpleSerializationTypeMap);
         });
 
+        var streamCompactionService = typeof(StreamCompactionService<,>);
+        var streamCompactor = typeof(IStreamCompactor<,>);
+        foreach (var compaction in config.Compactions)
+        {
+            var compactorInterface = streamCompactor.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType);
+            Services.AddSingleton(compactorInterface, compaction.CompactorType);
+            Services.AddSingleton(streamCompactionService.MakeGenericType(typeof(TBaseEvent), compaction.SnapshotType));
+        }
+
         return this;
     }
 }

--- a/src/LogOtter.CosmosDb.EventStore/EventStore/EventStore.cs
+++ b/src/LogOtter.CosmosDb.EventStore/EventStore/EventStore.cs
@@ -228,7 +228,13 @@ public class EventStore<TBaseEvent> : IEventStoreReader
             using var batchResponse = await batch.ExecuteAsync(cancellationToken);
             if (!batchResponse.IsSuccessStatusCode)
             {
-                throw new CosmosException(batchResponse.ErrorMessage, batchResponse.StatusCode, 0, batchResponse.ActivityId, batchResponse.RequestCharge);
+                throw new CosmosException(
+                    batchResponse.ErrorMessage,
+                    batchResponse.StatusCode,
+                    0,
+                    batchResponse.ActivityId,
+                    batchResponse.RequestCharge
+                );
             }
         }
     }

--- a/src/LogOtter.CosmosDb.EventStore/EventStore/EventStore.cs
+++ b/src/LogOtter.CosmosDb.EventStore/EventStore/EventStore.cs
@@ -8,6 +8,8 @@ namespace LogOtter.CosmosDb.EventStore;
 public class EventStore<TBaseEvent> : IEventStoreReader
     where TBaseEvent : class
 {
+    private const int MaxTransactionalBatchOperations = 100;
+
     private readonly Container _container;
     private readonly IFeedIteratorFactory _feedIteratorFactory;
     private readonly JsonSerializer _jsonSerializer;
@@ -169,6 +171,66 @@ public class EventStore<TBaseEvent> : IEventStoreReader
     public StorageEvent<TBaseEvent> FromCosmosStorageEvent(CosmosDbStorageEvent cosmosDbStorageEvent)
     {
         return cosmosDbStorageEvent.ToStorageEvent<TBaseEvent>(_typeMap, _jsonSerializer);
+    }
+
+    public async Task CompactStream(string streamId, EventData<TBaseEvent> tombstone, CancellationToken cancellationToken = default)
+    {
+        var existingEvents = await ReadStreamForwards(streamId, cancellationToken);
+
+        if (existingEvents.Count == 0)
+        {
+            return;
+        }
+
+        var tombstoneStorageEvent = new StorageEvent<TBaseEvent>(streamId, tombstone, 1);
+        var tombstoneCosmosEvent = CosmosDbStorageEvent.FromStorageEvent(tombstoneStorageEvent, _typeMap, _jsonSerializer);
+        var partitionKey = new PartitionKey(streamId);
+        var batchRequestOptions = new TransactionalBatchItemRequestOptions { EnableContentResponseOnWrite = false };
+
+        // Highest event numbers first — these are deleted in the first batch alongside the tombstone replace.
+        var eventNumbersToDelete = existingEvents.Where(e => e.EventNumber > 1).Select(e => e.EventNumber).OrderByDescending(n => n).ToList();
+
+        // Phase A (atomic): replace event 1 with the tombstone, plus as many tail deletes as fit in a 100-op batch.
+        // After this batch a crashed retry sees a stream whose first event is already the tombstone — projecting
+        // through ICompactionEvent yields the correct (scrubbed) state without needing the deleted events.
+        var firstBatch = _container.CreateTransactionalBatch(partitionKey);
+        firstBatch.ReplaceItem(tombstoneCosmosEvent.Id, tombstoneCosmosEvent, batchRequestOptions);
+
+        var firstBatchDeleteCount = Math.Min(eventNumbersToDelete.Count, MaxTransactionalBatchOperations - 1);
+        for (var i = 0; i < firstBatchDeleteCount; i++)
+        {
+            firstBatch.DeleteItem($"{streamId}:{eventNumbersToDelete[i]}", batchRequestOptions);
+        }
+
+        using var firstBatchResponse = await firstBatch.ExecuteAsync(cancellationToken);
+        if (!firstBatchResponse.IsSuccessStatusCode)
+        {
+            throw new CosmosException(
+                firstBatchResponse.ErrorMessage,
+                firstBatchResponse.StatusCode,
+                0,
+                firstBatchResponse.ActivityId,
+                firstBatchResponse.RequestCharge
+            );
+        }
+
+        // Phase B: delete any remaining tail events in 100-op batches.
+        var remaining = eventNumbersToDelete.Skip(firstBatchDeleteCount).ToList();
+        for (var offset = 0; offset < remaining.Count; offset += MaxTransactionalBatchOperations)
+        {
+            var batch = _container.CreateTransactionalBatch(partitionKey);
+            var batchSize = Math.Min(MaxTransactionalBatchOperations, remaining.Count - offset);
+            for (var i = 0; i < batchSize; i++)
+            {
+                batch.DeleteItem($"{streamId}:{remaining[offset + i]}", batchRequestOptions);
+            }
+
+            using var batchResponse = await batch.ExecuteAsync(cancellationToken);
+            if (!batchResponse.IsSuccessStatusCode)
+            {
+                throw new CosmosException(batchResponse.ErrorMessage, batchResponse.StatusCode, 0, batchResponse.ActivityId, batchResponse.RequestCharge);
+            }
+        }
     }
 
     private static async Task<TransactionalBatchResponse> CreateEvents(TransactionalBatch batch, CancellationToken cancellationToken)

--- a/src/LogOtter.CosmosDb.EventStore/Metadata/CompactionMetadata.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Metadata/CompactionMetadata.cs
@@ -1,3 +1,3 @@
-namespace LogOtter.CosmosDb.EventStore;
+namespace LogOtter.CosmosDb.EventStore.Metadata;
 
 internal record CompactionMetadata(Type CompactorType, Type SnapshotType);

--- a/src/LogOtter.CosmosDb.EventStore/README.md
+++ b/src/LogOtter.CosmosDb.EventStore/README.md
@@ -197,6 +197,134 @@ public class CustomerEventPublisher : ICatchupSubscription<CustomerEvent>
 
 ```
 
+ # Compacting a stream (GDPR erasure)
+
+Events are stored immutably, so when a GDPR Article 17 (right to erasure) request arrives, the PII contained in the event bodies has to be physically removed. Soft-deleting a projection (`ISnapshot.DeletedAt`) hides it from reads but leaves the underlying events — and their PII — in the store.
+
+Compaction solves this by replacing a stream's entire event history with a single **tombstone** event that reproduces a scrubbed version of the current projection (PII removed), then physically deleting the original events. After compaction the stream contains a single event at revision 1:
+
+```
+Before:
+  Event 1: CustomerCreated { Email: "alice@example.com", Name: "Alice Smith" }
+  Event 2: CustomerNameChanged { Name: "Alice Jones" }
+  Event 3: CustomerEmailChanged { Email: "alice.jones@example.com" }
+
+After:
+  Event 1: CustomerCompacted { Email: "[REDACTED]", Name: "[REDACTED]", CreatedOn: 2025-01-15 }
+```
+
+Compaction requires a projection with a snapshot (see [Adding a snapshot store](#adding-a-snapshot-store)) — the tombstone is derived by replaying the stream to the current projection, and the snapshot is upserted at revision 1.
+
+## Defining the scrubbing logic
+
+Implement `IStreamCompactor<TBaseEvent, TSnapshot>` to control exactly which fields are scrubbed and which are preserved. It receives the current projection and returns the tombstone event:
+
+```csharp
+using LogOtter.CosmosDb.EventStore;
+
+namespace Customer;
+
+public class CustomerStreamCompactor : IStreamCompactor<CustomerEvent, CustomerReadModel>
+{
+    public const string RedactedValue = "[REDACTED]";
+
+    public CustomerEvent CreateTombstoneEvent(CustomerReadModel currentProjection, string streamId)
+    {
+        return new CustomerCompacted(
+            currentProjection.CustomerUri,
+            emailAddress: RedactedValue,
+            firstName: RedactedValue,
+            lastName: RedactedValue,
+            createdOn: currentProjection.CreatedOn);
+    }
+}
+```
+
+The tombstone event must implement `ICompactionEvent`. This marker tells every read path to apply the tombstone and then stop — anything after it in the stream is ignored:
+
+```csharp
+using LogOtter.CosmosDb.EventStore;
+
+namespace Customer;
+
+public class CustomerCompacted(
+    CustomerUri customerUri,
+    string emailAddress,
+    string firstName,
+    string lastName,
+    DateTimeOffset createdOn
+) : CustomerEvent(customerUri), ICompactionEvent
+{
+    public string EmailAddress { get; } = emailAddress;
+    public string FirstName { get; } = firstName;
+    public string LastName { get; } = lastName;
+    public DateTimeOffset CreatedOn { get; } = createdOn;
+
+    public override void Apply(CustomerReadModel model, EventInfo eventInfo)
+    {
+        model.CustomerUri = CustomerUri;
+        model.EmailAddress = EmailAddress;
+        model.FirstName = FirstName;
+        model.LastName = LastName;
+        model.CreatedOn = CreatedOn;
+    }
+}
+```
+
+## Configuration
+
+Compaction is opt-in per event source. Chain a call to `.WithCompaction<TCompactor, TSnapshot>()`, where `TSnapshot` is a projection that already has a snapshot:
+
+```csharp
+services
+    .AddCosmosDb()
+    .WithAutoProvisioning()
+    .AddEventSourcing(options => options.AutoEscapeIds = true)
+    .AddEventSource<CustomerEvent>("CustomerEvents", c =>
+    {
+        c.AddProjection<CustomerReadModel>()
+            .WithSnapshot("Customers", _ => CustomerReadModel.StaticPartitionKey);
+
+        c.WithCompaction<CustomerStreamCompactor, CustomerReadModel>();
+    });
+```
+
+## Triggering compaction
+
+There are two ways to run a compaction.
+
+**Directly**, by requesting `StreamCompactionService<TBaseEvent, TSnapshot>` from the DI container and calling `CompactStream`:
+
+```csharp
+public class GdprDeletionService(
+    StreamCompactionService<CustomerEvent, CustomerReadModel> compactionService)
+{
+    public async Task HandleDeletionRequest(string customerId, CancellationToken ct)
+    {
+        await compactionService.CompactStream(customerId, ct);
+    }
+}
+```
+
+**Asynchronously via the change feed**, by appending an event that implements `ICompactionRequestedEvent<TSnapshot>`. Registering compaction also registers a `CompactionChangeFeedProcessor` that watches the stream and calls `CompactStream` whenever it sees such an event. This lets you request erasure using the normal `ApplyEvents`/`AppendToStream` flow:
+
+```csharp
+public class CustomerCompactionRequested(CustomerUri customerUri)
+    : CustomerEvent(customerUri), ICompactionRequestedEvent<CustomerReadModel>
+{
+    public override void Apply(CustomerReadModel model, EventInfo eventInfo)
+    {
+        // No projection change — this event exists purely as a signal to the compaction processor.
+    }
+}
+```
+
+## Behaviour to be aware of
+
+- **Revision resets to 1.** After compaction the stream is a single tombstone at revision 1. Any in-flight write holding a stale revision will get a `ConcurrencyException` on its next append and must retry.
+- **Post-compaction appends are ignored by projections.** The raw store accepts appends at position 2+ after compaction, but every projection read path stops at the tombstone, so those events are invisible to consumers. Once a stream is compacted the entity is logically gone and no further activity is expected; streams that must stay live after compaction are out of scope.
+- **Idempotent.** Compacting a stream whose first event is already a tombstone reuses that tombstone verbatim rather than re-deriving the projection, so retrying after a partial failure is safe.
+
 # Usage
 
 Depending on the setup steps you have used, you'll have one or more of the following:

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/EventRepository.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/EventRepository.cs
@@ -28,6 +28,15 @@ public class EventRepository<TBaseEvent, TSnapshot>(EventStore<TBaseEvent> event
         foreach (var @event in events)
         {
             @event.EventBody.Apply(model, new(@event.CreatedOn, @event.EventNumber, @event.Metadata));
+
+            // A compaction tombstone fully represents the stream state. Any subsequent events are
+            // either pending deletion (during in-flight cleanup) or stale leftovers from a crashed
+            // compaction — stop applying so they don't corrupt the projection.
+            if (@event.EventBody is ICompactionEvent)
+            {
+                model.Revision = 1;
+                break;
+            }
         }
 
         if (model.DeletedAt.HasValue && !includeDeleted)

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/HybridRepository.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/HybridRepository.cs
@@ -116,6 +116,14 @@ public class HybridRepository<TBaseEvent, TSnapshot>(
 
         foreach (var @event in eventStoreEvents)
         {
+            if (@event.EventBody is ICompactionEvent)
+            {
+                snapshot = new TSnapshot { Id = streamId };
+                @event.EventBody.Apply(snapshot, new(@event.CreatedOn, @event.EventNumber, @event.Metadata));
+                snapshot.Revision = 1;
+                break;
+            }
+
             @event.EventBody.Apply(snapshot, new(@event.CreatedOn, @event.EventNumber, @event.Metadata));
             snapshot.Revision++;
         }

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/ICompactionEvent.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/ICompactionEvent.cs
@@ -1,0 +1,8 @@
+namespace LogOtter.CosmosDb.EventStore;
+
+/// <summary>
+/// Marks an event as a stream-compaction tombstone. When a read path encounters one of these,
+/// it applies it and stops — any subsequent events in the stream are pending deletion and must
+/// not contribute to the projection.
+/// </summary>
+public interface ICompactionEvent;

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/ICompactionRequestedEvent.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/ICompactionRequestedEvent.cs
@@ -1,0 +1,7 @@
+namespace LogOtter.CosmosDb.EventStore;
+
+/// <summary>
+///  Marks the event stream as requesting a compaction, the Compaction CFP will attempt to resolve and execute the compaction against the event stream
+/// </summary>
+public interface ICompactionRequestedEvent<TSnapshot> : IEvent<TSnapshot>
+    where TSnapshot : ISnapshot;

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/IStreamCompactor.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/IStreamCompactor.cs
@@ -1,0 +1,8 @@
+namespace LogOtter.CosmosDb.EventStore;
+
+public interface IStreamCompactor<TBaseEvent, TSnapshot>
+    where TBaseEvent : class, IEvent<TSnapshot>
+    where TSnapshot : class, ISnapshot, new()
+{
+    TBaseEvent CreateTombstoneEvent(TSnapshot currentProjection, string streamId);
+}

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/SnapshotRepository.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/SnapshotRepository.cs
@@ -103,6 +103,17 @@ public class SnapshotRepository<TBaseEvent, TSnapshot>(
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (@event.Body is ICompactionEvent)
+            {
+                // Tombstone resets the snapshot to its scrubbed state regardless of current revision.
+                // Stop processing further events in this batch — anything after is either pending
+                // deletion or a stale leftover from a crashed compaction.
+                snapshot = new TSnapshot { Id = streamId };
+                @event.Body.Apply(snapshot, new(@event.CreatedOn, @event.EventNumber, @event.Metadata));
+                snapshot.Revision = @event.EventNumber;
+                break;
+            }
+
             if (snapshot.Revision >= @event.EventNumber)
             {
                 continue;
@@ -120,6 +131,11 @@ public class SnapshotRepository<TBaseEvent, TSnapshot>(
         );
 
         cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    public async Task UpsertSnapshot(TSnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        await _snapshotContainer.UpsertItemAsync(snapshot, new PartitionKey(snapshot.PartitionKey), cancellationToken: cancellationToken);
     }
 
     private async Task<(TSnapshot Snapshot, string ETag)?> GetSnapshotInternal(

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/StreamCompactionService.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/StreamCompactionService.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Options;
+
+namespace LogOtter.CosmosDb.EventStore;
+
+public class StreamCompactionService<TBaseEvent, TSnapshot>(
+    EventStore<TBaseEvent> eventStore,
+    SnapshotRepository<TBaseEvent, TSnapshot> snapshotRepository,
+    IStreamCompactor<TBaseEvent, TSnapshot> compactor,
+    IOptions<EventStoreOptions> options
+)
+    where TBaseEvent : class, IEvent<TSnapshot>
+    where TSnapshot : class, ISnapshot, new()
+{
+    private readonly EventStoreOptions _options = options.Value;
+
+    public async Task CompactStream(string id, CancellationToken cancellationToken = default)
+    {
+        var streamId = _options.EscapeIdIfRequired(id);
+
+        var existingEvents = await eventStore.ReadStreamForwards(streamId, cancellationToken);
+
+        if (existingEvents.Count == 0)
+        {
+            return;
+        }
+
+        var firstEvent = existingEvents.First();
+
+        EventData<TBaseEvent> tombstoneData;
+
+        if (firstEvent.EventBody is ICompactionEvent)
+        {
+            // Resuming a previously-started compaction: the tombstone is already in place. Reuse it
+            // verbatim — id, timestamp, metadata, body — rather than re-deriving the projection.
+            // Events 2..N may have been partly deleted by the previous attempt, so a fresh projection
+            // would be built from a truncated stream and produce a stale tombstone.
+            tombstoneData = new EventData<TBaseEvent>(firstEvent.EventId, firstEvent.EventBody, firstEvent.CreatedOn, firstEvent.Metadata);
+        }
+        else
+        {
+            var projection = new TSnapshot { Id = streamId, Revision = existingEvents.Count };
+            foreach (var @event in existingEvents)
+            {
+                @event.EventBody.Apply(projection, new EventInfo(@event.CreatedOn, @event.EventNumber, @event.Metadata));
+            }
+
+            var tombstone = compactor.CreateTombstoneEvent(projection, streamId);
+            tombstoneData = new EventData<TBaseEvent>(Guid.NewGuid(), tombstone, DateTimeOffset.Now);
+        }
+
+        await eventStore.CompactStream(streamId, tombstoneData, cancellationToken);
+
+        var compactedSnapshot = new TSnapshot { Id = streamId, Revision = 1 };
+        tombstoneData.Body.Apply(compactedSnapshot, new EventInfo(tombstoneData.CreatedOn, 1, tombstoneData.Metadata));
+
+        await snapshotRepository.UpsertSnapshot(compactedSnapshot, cancellationToken);
+    }
+}

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/StreamCompactionServiceTests.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/StreamCompactionServiceTests.cs
@@ -1,0 +1,321 @@
+using LogOtter.CosmosDb.EventStore.Tests.TestEvents;
+using LogOtter.CosmosDb.Testing;
+using Microsoft.Extensions.Options;
+
+namespace LogOtter.CosmosDb.EventStore.Tests;
+
+public class StreamCompactionServiceTests
+{
+    [Fact]
+    public async Task CompactSingleEventStreamReplacesEventWithTombstone()
+    {
+        var (compactionService, eventStore, _, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(id, 0, new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow));
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.First().EventBody.ShouldBeOfType<TestEventCompacted>().ScrubbedName.ShouldBe("[REDACTED]");
+        events.First().EventNumber.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CompactMultiEventStreamDeletesOriginalEvents()
+    {
+        var (compactionService, eventStore, _, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Alice Smith"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Alice Jones"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.First().EventNumber.ShouldBe(1);
+        events.First().EventBody.ShouldBeOfType<TestEventCompacted>();
+    }
+
+    [Fact]
+    public async Task AppendAfterCompactionIsIgnoredByProjection()
+    {
+        // Stream-level append-after-compaction still works (the raw store doesn't know about
+        // tombstones), but the read path treats anything after the tombstone as a leftover and
+        // drops it from the projection. This is the cost of the safe-retry design: once a stream
+        // is compacted, its state is frozen at the tombstone.
+        var (compactionService, eventStore, eventRepository, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Alice Smith"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        await eventStore.AppendToStream(id, 1, new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "New Name"), DateTimeOffset.UtcNow));
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(2, "the raw store accepts the append");
+
+        var projection = await eventRepository.Get(id, cancellationToken: TestContext.Current.CancellationToken);
+        projection.ShouldNotBeNull();
+        projection.Name.ShouldBe("[REDACTED]", "the projection stops at the tombstone and ignores subsequent events");
+    }
+
+    [Fact]
+    public async Task CompactingEmptyStreamIsNoOp()
+    {
+        var (compactionService, eventStore, _, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task CompactLargeStreamWithMoreThan100EventsWorksAcrossBatches()
+    {
+        var (compactionService, eventStore, _, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        var initial = new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow);
+        await eventStore.AppendToStream(id, 0, initial);
+
+        // append 250 more events one at a time so each goes in its own append (avoids large transactional batch on insert)
+        for (var i = 0; i < 250; i++)
+        {
+            var modified = new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, $"Name {i}"), DateTimeOffset.UtcNow);
+            await eventStore.AppendToStream(id, i + 1, modified);
+        }
+
+        var totalBefore = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        totalBefore.Count.ShouldBe(251);
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.First().EventNumber.ShouldBe(1);
+        events.First().EventBody.ShouldBeOfType<TestEventCompacted>();
+    }
+
+    [Fact]
+    public async Task RecompactingAnAlreadyCompactedStreamIsSafe()
+    {
+        var (compactionService, eventStore, _, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Bob"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.First().EventNumber.ShouldBe(1);
+        events.First().EventBody.ShouldBeOfType<TestEventCompacted>();
+    }
+
+    [Fact]
+    public async Task CompactionResetsRepositoryRevisionToOne()
+    {
+        var (compactionService, _, eventRepository, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventRepository.ApplyEvents(
+            id,
+            null,
+            new TestEventCreated(id, "Alice"),
+            new TestEventModified(id, "Bob"),
+            new TestEventModified(id, "Charlie")
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var snapshot = await eventRepository.Get(id, cancellationToken: TestContext.Current.CancellationToken);
+        snapshot.ShouldNotBeNull();
+        snapshot.Revision.ShouldBe(1);
+        snapshot.Name.ShouldBe("[REDACTED]");
+    }
+
+    [Fact]
+    public async Task AppendWithStaleRevisionAfterCompactionThrowsConcurrencyException()
+    {
+        var (compactionService, eventStore, _, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Bob"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Charlie"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var staleAppend = async () =>
+            await eventStore.AppendToStream(
+                id,
+                3,
+                new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Dave"), DateTimeOffset.UtcNow)
+            );
+
+        await staleAppend.ShouldThrowAsync<ConcurrencyException>();
+    }
+
+    [Fact]
+    public async Task PartiallyCompactedStream_Retry_ProducesTombstoneStateRegardlessOfLeftovers()
+    {
+        // Simulates a crash mid-compaction: the tombstone is in place at event 1, but tail cleanup
+        // didn't finish so events 2..K still linger. With the old design, retrying would re-derive
+        // the projection from the truncated stream and produce a stale tombstone. With the new
+        // design (tombstone-first + ICompactionEvent marker), the retry reuses the existing
+        // tombstone — the original state is preserved.
+        var (compactionService, eventStore, eventRepository, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Bob"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Charlie"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        // Simulate a stale leftover from a crashed cleanup: append an event after the tombstone.
+        // (In real life this would be a leftover event that the cleanup hadn't deleted yet, or a
+        // concurrent write that snuck in. AppendToStream still works because event 1 exists.)
+        await eventStore.AppendToStream(
+            id,
+            1,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Stale Leftover"), DateTimeOffset.UtcNow)
+        );
+
+        // Projection must still reflect the tombstone — leftovers do not corrupt the read.
+        var snapshotBeforeRetry = await eventRepository.Get(id, cancellationToken: TestContext.Current.CancellationToken);
+        snapshotBeforeRetry.ShouldNotBeNull();
+        snapshotBeforeRetry.Name.ShouldBe("[REDACTED]");
+        snapshotBeforeRetry.Revision.ShouldBe(1);
+
+        // Retry compaction — should clean up the leftover and keep the tombstone state.
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.First().EventBody.ShouldBeOfType<TestEventCompacted>().ScrubbedName.ShouldBe("[REDACTED]");
+
+        var snapshotAfterRetry = await eventRepository.Get(id, cancellationToken: TestContext.Current.CancellationToken);
+        snapshotAfterRetry.ShouldNotBeNull();
+        snapshotAfterRetry.Name.ShouldBe("[REDACTED]");
+    }
+
+    [Fact]
+    public async Task RetryDoesNotRederiveProjectionFromTruncatedStream()
+    {
+        // The core invariant from the proposal review: after a partial compaction, the retry must
+        // not pass leftover events back through the compactor and produce a stale tombstone.
+        var (compactionService, eventStore, eventRepository, _) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+
+        // Pre-set: tombstone scrubs "Charlie" (the original final state)
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Bob"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Charlie"), DateTimeOffset.UtcNow)
+        );
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        // Inject a misleading leftover — its NewName is different from the original final state.
+        // If the retry re-derived the projection it would see [tombstone, "Wrong"] and the
+        // compactor would scrub "Wrong" into the tombstone. The tombstone EventId would change.
+        var originalTombstone = (await eventStore.ReadStreamForwards(id, TestContext.Current.CancellationToken)).Single();
+        await eventStore.AppendToStream(
+            id,
+            1,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Wrong State"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
+        events.Count.ShouldBe(1);
+        events.First().EventId.ShouldBe(originalTombstone.EventId, "the retry should reuse the original tombstone rather than synthesise a new one from the truncated stream");
+    }
+
+    [Fact]
+    public async Task CompactionUpsertsSnapshotAtRevisionOne()
+    {
+        var (compactionService, eventStore, _, snapshotRepository) = CreateServices();
+
+        var id = Guid.NewGuid().ToString();
+        await eventStore.AppendToStream(
+            id,
+            0,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventCreated(id, "Alice"), DateTimeOffset.UtcNow),
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "Bob"), DateTimeOffset.UtcNow)
+        );
+
+        await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
+
+        var snapshot = await snapshotRepository.GetSnapshot(
+            id,
+            TestEventProjection.StaticPartitionKey,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        snapshot.ShouldNotBeNull();
+        snapshot.Revision.ShouldBe(1);
+        snapshot.Name.ShouldBe("[REDACTED]");
+    }
+
+    private static (
+        StreamCompactionService<TestEvent, TestEventProjection> compactionService,
+        EventStore<TestEvent> eventStore,
+        EventRepository<TestEvent, TestEventProjection> eventRepository,
+        SnapshotRepository<TestEvent, TestEventProjection> snapshotRepository
+    ) CreateServices()
+    {
+        var container = new ContainerMock.ContainerMock();
+        var snapshotContainer = new ContainerMock.ContainerMock();
+        var feedIteratorFactory = new TestFeedIteratorFactory();
+        var serializationTypeMap = new SimpleSerializationTypeMap(
+            new[] { typeof(TestEventCreated), typeof(TestEventModified), typeof(TestEventCompacted) }
+        );
+        var eventStore = new EventStore<TestEvent>(container, feedIteratorFactory, serializationTypeMap);
+        var options = new OptionsWrapper<EventStoreOptions>(new EventStoreOptions());
+        var eventRepository = new EventRepository<TestEvent, TestEventProjection>(eventStore, options);
+        var snapshotRepository = new SnapshotRepository<TestEvent, TestEventProjection>(
+            new CosmosContainer<TestEventProjection>(snapshotContainer),
+            eventStore,
+            feedIteratorFactory,
+            options
+        );
+        var compactor = new TestStreamCompactor();
+        var compactionService = new StreamCompactionService<TestEvent, TestEventProjection>(eventStore, snapshotRepository, compactor, options);
+        return (compactionService, eventStore, eventRepository, snapshotRepository);
+    }
+}

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/StreamCompactionServiceTests.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/StreamCompactionServiceTests.cs
@@ -63,7 +63,11 @@ public class StreamCompactionServiceTests
 
         await compactionService.CompactStream(id, TestContext.Current.CancellationToken);
 
-        await eventStore.AppendToStream(id, 1, new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "New Name"), DateTimeOffset.UtcNow));
+        await eventStore.AppendToStream(
+            id,
+            1,
+            new EventData<TestEvent>(Guid.NewGuid(), new TestEventModified(id, "New Name"), DateTimeOffset.UtcNow)
+        );
 
         var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(2, "the raw store accepts the append");
@@ -264,7 +268,12 @@ public class StreamCompactionServiceTests
 
         var events = await eventStore.ReadStreamForwards(id, cancellationToken: TestContext.Current.CancellationToken);
         events.Count.ShouldBe(1);
-        events.First().EventId.ShouldBe(originalTombstone.EventId, "the retry should reuse the original tombstone rather than synthesise a new one from the truncated stream");
+        events
+            .First()
+            .EventId.ShouldBe(
+                originalTombstone.EventId,
+                "the retry should reuse the original tombstone rather than synthesise a new one from the truncated stream"
+            );
     }
 
     [Fact]

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/TestEvents/TestEventCompacted.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/TestEvents/TestEventCompacted.cs
@@ -1,0 +1,11 @@
+namespace LogOtter.CosmosDb.EventStore.Tests.TestEvents;
+
+public class TestEventCompacted(string id, string scrubbedName) : TestEvent(id), ICompactionEvent
+{
+    public string ScrubbedName { get; } = scrubbedName;
+
+    public override void Apply(TestEventProjection model, EventInfo eventInfo)
+    {
+        model.Name = ScrubbedName;
+    }
+}

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/TestEvents/TestEventProjection.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/TestEvents/TestEventProjection.cs
@@ -4,7 +4,7 @@ namespace LogOtter.CosmosDb.EventStore.Tests.TestEvents;
 
 public class TestEventProjection : ISnapshot
 {
-    private const string StaticPartitionKey = "/test";
+    public const string StaticPartitionKey = "/test";
 
     public int Revision { get; set; }
 

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/TestEvents/TestStreamCompactor.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/TestEvents/TestStreamCompactor.cs
@@ -1,0 +1,9 @@
+namespace LogOtter.CosmosDb.EventStore.Tests.TestEvents;
+
+public class TestStreamCompactor : IStreamCompactor<TestEvent, TestEventProjection>
+{
+    public TestEvent CreateTombstoneEvent(TestEventProjection currentProjection, string streamId)
+    {
+        return new TestEventCompacted(streamId, "[REDACTED]");
+    }
+}


### PR DESCRIPTION
We want to support deletion requests for GDPR compliance as currently events are append only, and don't support scrubbing data.
Adding Compaction of event streams into a single Tombstone event allows us to redact the data for a given event stream.

Compacted streams will not read further than the tombstone event, so the developer using the library is recommended to set the deleted flag on the compaction event.
Compaction is an idempotent operation as the first event in the stream will be re-written and following events deleted (if operation fails part way through it will leave dangling later events, but they are not read if the event stream finds a compaction event)

I've also added in a CFP which will auto register when a compaction type is registered. If it finds any events in the stream which inherit from ICompactionRequestedEvent it will kick off the compaction service so developers don't need to have an endpoint which is called with retries