### PR TITLE
Add Data Enrichers and Manual Metadata overrides to event writing

### DIFF
--- a/docs/poposals/metadata-writing-proposal.md
+++ b/docs/poposals/metadata-writing-proposal.md
@@ -1,0 +1,166 @@
+# Proposal: Writing Metadata to Stored Events
+
+## Background
+
+Log Otter's event store already has first-class metadata support end-to-end. Every event carries a `Dictionary<string, string> Metadata` field that is persisted to Cosmos DB, survives reads, and is surfaced to catch-up subscription handlers via `Event<T>.Metadata` and to projection apply methods via `EventInfo.Metadata`.
+
+The gap is on the **write path**. `EventRepository.ApplyEvents()` currently hard-codes an empty metadata dictionary when creating `EventData` instances (line 73, `EventRepository.cs`). There is no mechanism for callers — or ambient infrastructure — to inject metadata such as distributed trace context before events are written.
+
+## Problem
+
+When debugging or tracing requests across services, engineers want to correlate events stored in the event store with the distributed trace that triggered the write. Without metadata on stored events, there is no link between a trace in (e.g.) Jaeger or Honeycomb and the causally-related events in Cosmos DB.
+
+Fixing this by having every call-site manually construct and pass a metadata dictionary is error-prone and creates noise in business logic — callers should not have to know about tracing infrastructure.
+
+## Goals
+
+- Automatically capture the current W3C trace context (`traceparent` / `tracestate`) and write it into event metadata at append time.
+- Provide a general-purpose extension point so that other metadata (e.g. user identity, tenant ID, correlation IDs) can be injected by application code without modifying the library.
+- Require zero changes to existing call-sites for the common (trace context only) case.
+- Introduce no mandatory new package dependencies.
+
+## Non-goals
+
+- Propagating metadata from stored events back into outgoing requests when events are replayed (a separate concern for handlers).
+- Defining a fixed schema or reserved keys for metadata fields (beyond the trace context convention below).
+
+---
+
+## Proposed Design
+
+### Core interface: `IEventMetadataEnricher`
+
+A new interface in `LogOtter.CosmosDb.EventStore`:
+
+```csharp
+public interface IEventMetadataEnricher
+{
+    void Enrich(IDictionary<string, string> metadata);
+}
+```
+
+`EventRepository` resolves `IEnumerable<IEventMetadataEnricher>` from DI and calls each one to build a metadata dictionary before constructing `EventData` instances. Because enrichers run once per `ApplyEvents` call (not per individual event), all events in a single batch share the same metadata — which is correct, since they all originate from the same request/trace.
+
+### Changes to `EventRepository`
+
+`EventRepository` gains a constructor parameter `IEnumerable<IEventMetadataEnricher>? metadataEnrichers = null`. The default value keeps existing **manual** construction (e.g. in tests) compiling; the `null` is coalesced to an empty collection. No change is needed in `EventSourcingBuilder` — `EventRepository` is registered as an open-generic singleton, and the DI container automatically resolves `IEnumerable<IEventMetadataEnricher>` (an empty enumerable when nothing is registered).
+
+In both `ApplyEvents` and `ApplyAndGetEvents`, the hard-coded `new EventData<TBaseEvent>(Guid.NewGuid(), e, now)` call becomes:
+
+```csharp
+var metadata = BuildMetadata();
+var eventData = events.Select(e => new EventData<TBaseEvent>(Guid.NewGuid(), e, now, metadata)).ToArray();
+```
+
+where `BuildMetadata()` invokes each registered enricher:
+
+```csharp
+private Dictionary<string, string> BuildMetadata()
+{
+    var metadata = new Dictionary<string, string>();
+    foreach (var enricher in _metadataEnrichers)
+        enricher.Enrich(metadata);
+    return metadata;
+}
+```
+
+All events in the batch share the same `metadata` dictionary reference. This is safe because the dictionary is never mutated after `BuildMetadata()` returns — enrichers run only during the build.
+
+The `Apply()` call site on line 70 also passes the metadata snapshot so the in-memory projection sees the same values:
+
+```csharp
+eventToApply.Apply(entity, new(now, ++revision, metadata));
+```
+
+### Built-in enricher: `ActivityMetadataEnricher`
+
+`System.Diagnostics.Activity` is part of the BCL (no additional packages required). The enricher reads the current activity's W3C trace context and writes the standard header names:
+
+```csharp
+public sealed class ActivityMetadataEnricher : IEventMetadataEnricher
+{
+    public void Enrich(IDictionary<string, string> metadata)
+    {
+        var activity = Activity.Current;
+        if (activity is null)
+            return;
+
+        // W3C traceparent: 00-{traceId}-{spanId}-{flags}
+        metadata["traceparent"] = activity.Id!;
+
+        if (!string.IsNullOrEmpty(activity.TraceStateString))
+            metadata["tracestate"] = activity.TraceStateString;
+    }
+}
+```
+
+This integrates transparently with any OTel SDK that uses `ActivitySource` (the standard .NET OTel approach), as well as with `HttpClient` propagation via the built-in `DistributedContextPropagator`.
+
+### Registration API
+
+```csharp
+// Register just the Activity enricher (trace context only)
+builder.Services.AddEventMetadataEnricher<ActivityMetadataEnricher>();
+
+// Or add custom enrichers alongside it
+builder.Services.AddEventMetadataEnricher<TenantMetadataEnricher>();
+```
+
+`AddEventMetadataEnricher<T>` is a simple extension method that calls `services.AddSingleton<IEventMetadataEnricher, T>()`.
+
+The `ActivityMetadataEnricher` is **opt-in** — it is not registered by default, so existing deployments are unaffected until they add the registration.
+
+---
+
+## Alternative: Explicit metadata parameter
+
+As a secondary, complementary mechanism, overloads of `ApplyEvents` and `ApplyAndGetEvents` can accept a caller-supplied `IReadOnlyDictionary<string, string>? additionalMetadata` parameter. The repository merges this with enricher output (enrichers run first; caller-supplied values override on key collision).
+
+This is useful for:
+- Integration tests that want to assert specific metadata is stored.
+- Application code that has metadata not available via ambient context (e.g. idempotency keys).
+
+This is lower priority than the enricher mechanism — the enricher approach covers the tracing use case without any call-site changes.
+
+---
+
+## Key metadata names (convention)
+
+| Key | Value | Source |
+|---|---|---|
+| `traceparent` | W3C traceparent string | `Activity.Current.Id` |
+| `tracestate` | W3C tracestate string | `Activity.Current.TraceStateString` |
+
+These follow the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification, making the values directly interpretable by any W3C-compatible tracing backend.
+
+---
+
+## Affected files
+
+| File | Change |
+|---|---|
+| `Repositories/EventRepository.cs` | Accept `IEnumerable<IEventMetadataEnricher>?`, add `additionalMetadata` overloads, call `BuildMetadata()` before creating `EventData` and pass metadata to `Apply()` |
+| `MetadataEnrichers/IEventMetadataEnricher.cs` (new) | Define the enricher interface |
+| `MetadataEnrichers/ActivityMetadataEnricher.cs` (new) | Built-in W3C trace context enricher (guards on `IdFormat == W3C`) |
+| `MetadataEnrichers/EventMetadataEnricherExtensions.cs` (new) | `AddEventMetadataEnricher<T>()` helper (uses `TryAddEnumerable`) |
+| `sample/CustomerApi/Program.cs` | Demonstrates opt-in registration of `ActivityMetadataEnricher` |
+
+No changes to `EventSourcingBuilder` (DI auto-resolves the enricher collection), the storage layer (`EventStore`, `CosmosDbStorageEvent`) or the read path — the metadata plumbing already exists there.
+
+---
+
+## Resolved decisions
+
+1. **Package placement** — `ActivityMetadataEnricher` lives in the core `LogOtter.CosmosDb.EventStore` package. It has no extra dependencies (`Activity` is BCL), so a separate package was not warranted.
+
+2. **Enricher ordering** — Registration order is sufficient; the interface exposes no priority property. Caller-supplied `additionalMetadata` (below) always wins on key collision regardless of enricher order.
+
+3. **Per-event vs per-batch metadata** — Per-batch: all events in a batch share one metadata snapshot, since they originate from the same request/trace.
+
+4. **Apply() metadata** — `EventInfo.Metadata` **is** populated with the write-time metadata during in-memory apply, for consistency with the read path. (Note: this metadata reflects what *will* be written; the `AppendToStream` call could still fail afterwards.)
+
+5. **Enricher lifetime** — Enrichers are registered as singletons. To read per-request state, an enricher should depend on an ambient accessor (`Activity.Current`, `IHttpContextAccessor`) and resolve it inside `Enrich()`, rather than capturing a scoped service.
+
+## Security note
+
+Event metadata is persisted to Cosmos DB and is readable by anyone with access to the container. It is **not** currently surfaced by the EventStreams API response DTO. Because the enricher extension point accepts arbitrary data, callers must not write secrets, credentials or sensitive personal data into metadata. W3C trace context is non-sensitive.

--- a/sample/CustomerApi/Program.cs
+++ b/sample/CustomerApi/Program.cs
@@ -75,6 +75,9 @@ services
         }
     );
 
+// Opt-in: capture the current W3C trace context into event metadata as events are appended.
+services.AddEventMetadataEnricher<ActivityMetadataEnricher>();
+
 services.AddHealthChecks().AddCheck<ResolveAllControllersHealthCheck>("Resolve All Controllers");
 
 if (environment.IsDevelopment())

--- a/src/LogOtter.CosmosDb.EventStore/MetadataEnrichers/ActivityMetadataEnricher.cs
+++ b/src/LogOtter.CosmosDb.EventStore/MetadataEnrichers/ActivityMetadataEnricher.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+
+namespace LogOtter.CosmosDb.EventStore;
+
+/// <summary>
+/// Writes the current <see cref="Activity"/>'s W3C trace context into event metadata, so stored events
+/// can be correlated with the distributed trace that produced them.
+/// </summary>
+/// <remarks>
+/// Only emits values when the current activity uses the W3C id format (the .NET default). Hierarchical
+/// (legacy) activities are ignored because their <see cref="Activity.Id"/> is not a valid <c>traceparent</c>.
+/// </remarks>
+public sealed class ActivityMetadataEnricher : IEventMetadataEnricher
+{
+    public void Enrich(IDictionary<string, string> metadata)
+    {
+        var activity = Activity.Current;
+        if (activity is null || activity.IdFormat != ActivityIdFormat.W3C)
+        {
+            return;
+        }
+
+        // W3C traceparent: 00-{traceId}-{spanId}-{flags}
+        if (!string.IsNullOrEmpty(activity.Id))
+        {
+            metadata["traceparent"] = activity.Id;
+        }
+
+        if (!string.IsNullOrEmpty(activity.TraceStateString))
+        {
+            metadata["tracestate"] = activity.TraceStateString;
+        }
+    }
+}

--- a/src/LogOtter.CosmosDb.EventStore/MetadataEnrichers/EventMetadataEnricherExtensions.cs
+++ b/src/LogOtter.CosmosDb.EventStore/MetadataEnrichers/EventMetadataEnricherExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace LogOtter.CosmosDb.EventStore;
+
+public static class EventMetadataEnricherExtensions
+{
+    /// <summary>
+    /// Registers an <see cref="IEventMetadataEnricher"/> that contributes metadata to events as they are appended.
+    /// Enrichers are opt-in: none are registered by default. Registering the same enricher type more than once is a no-op.
+    /// </summary>
+    public static IServiceCollection AddEventMetadataEnricher<TEnricher>(this IServiceCollection services)
+        where TEnricher : class, IEventMetadataEnricher
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IEventMetadataEnricher, TEnricher>());
+        return services;
+    }
+}

--- a/src/LogOtter.CosmosDb.EventStore/MetadataEnrichers/IEventMetadataEnricher.cs
+++ b/src/LogOtter.CosmosDb.EventStore/MetadataEnrichers/IEventMetadataEnricher.cs
@@ -1,0 +1,20 @@
+namespace LogOtter.CosmosDb.EventStore;
+
+/// <summary>
+/// Contributes metadata that is written alongside events when they are appended to a stream.
+/// Enrichers are invoked once per <c>ApplyEvents</c>/<c>ApplyAndGetEvents</c> call, so every event
+/// in a batch shares the same metadata snapshot.
+/// </summary>
+/// <remarks>
+/// Enrichers are registered as singletons (see <c>AddEventMetadataEnricher</c>) and resolved into the
+/// singleton <see cref="EventRepository{TBaseEvent,TSnapshot}"/>. To read per-request state, depend on an
+/// ambient accessor (e.g. <c>IHttpContextAccessor</c> or <c>Activity.Current</c>) and resolve it inside
+/// <see cref="Enrich"/> rather than capturing a scoped service in the constructor.
+///
+/// Metadata is persisted to Cosmos DB and is readable by anyone with access to the underlying container.
+/// Do not write secrets, credentials or sensitive personal data into metadata.
+/// </remarks>
+public interface IEventMetadataEnricher
+{
+    void Enrich(IDictionary<string, string> metadata);
+}

--- a/src/LogOtter.CosmosDb.EventStore/README.md
+++ b/src/LogOtter.CosmosDb.EventStore/README.md
@@ -295,6 +295,19 @@ var customer = await _customerEventRepository.ApplyEvents(
     customerCreated);
 ```
 
+Each `ApplyEvents` (and `ApplyAndGetEvents`) call also has an overload that accepts an `IReadOnlyDictionary<string, string>? additionalMetadata`, which is stored alongside the events. See [Writing metadata to events](#writing-metadata-to-events).
+
+```csharp
+var additionalMetadata = new Dictionary<string, string> { ["idempotencyKey"] = idempotencyKey };
+
+var customer = await _customerEventRepository.ApplyEvents(
+    customerUri,
+    0,
+    additionalMetadata,
+    cancellationToken,
+    customerCreated);
+```
+
 ### GetEventStream
 
 This method is a thin layer on top of the `EventStore`'s `ReadStreamForwards` method. It will read the whole stream and extract the `TBaseEvent` from the `StorageEvent`, giving you the full stream of `TBaseEvent`:
@@ -303,6 +316,75 @@ This method is a thin layer on top of the `EventStore`'s `ReadStreamForwards` me
 var customerEvents = await _customerEventRepository.GetEventStream(
     customerUri,
     cancellationToken);
+```
+
+# Writing metadata to events
+
+Every stored event carries a `Dictionary<string, string> Metadata` that is persisted to Cosmos DB and surfaced back to catch-up subscription handlers (`Event<T>.Metadata`) and projection apply methods (`EventInfo.Metadata`). There are two ways to populate it when appending events.
+
+> ⚠️ Metadata is persisted and readable by anyone with access to the underlying Cosmos DB container. Do not write secrets, credentials or sensitive personal data into it.
+
+## Enrichers (ambient metadata)
+
+An `IEventMetadataEnricher` contributes metadata automatically, so call-sites don't have to know about it. Enrichers run once per `ApplyEvents`/`ApplyAndGetEvents` call, and every event in that batch shares the same metadata snapshot.
+
+```csharp
+public interface IEventMetadataEnricher
+{
+    void Enrich(IDictionary<string, string> metadata);
+}
+```
+
+Register enrichers in your service configuration. They are opt-in — none are registered by default:
+
+```csharp
+services.AddEventMetadataEnricher<ActivityMetadataEnricher>();
+```
+
+Enrichers are registered as singletons and resolved into the (singleton) `EventRepository`. To read per-request state, depend on an ambient accessor (e.g. `Activity.Current` or `IHttpContextAccessor`) and read it inside `Enrich()` rather than injecting a scoped service into the constructor:
+
+```csharp
+public sealed class UserMetadataEnricher(IHttpContextAccessor accessor) : IEventMetadataEnricher
+{
+    public void Enrich(IDictionary<string, string> metadata)
+    {
+        var userId = accessor.HttpContext?.User.FindFirst("sub")?.Value;
+        if (userId is not null)
+        {
+            metadata["userId"] = userId;
+        }
+    }
+}
+```
+
+### ActivityMetadataEnricher
+
+`ActivityMetadataEnricher` is a built-in enricher that captures the current [W3C trace context](https://www.w3.org/TR/trace-context/) from `Activity.Current`, so stored events can be correlated with the distributed trace that produced them:
+
+| Key | Value |
+|---|---|
+| `traceparent` | `Activity.Current.Id` (only when the activity uses the W3C id format) |
+| `tracestate` | `Activity.Current.TraceStateString` (when non-empty) |
+
+```csharp
+services.AddEventMetadataEnricher<ActivityMetadataEnricher>();
+```
+
+This works with any OpenTelemetry SDK that uses `ActivitySource`, as well as `HttpClient` propagation. Note that `Activity.Current` must be present on the async flow at append time — if you defer writes to a background service or queue, the ambient context will be gone, so use the explicit `additionalMetadata` overload (below) to carry the context.
+
+## Explicit metadata (per-call)
+
+When metadata isn't available via ambient context (e.g. an idempotency key), pass it directly to the `additionalMetadata` overload of `ApplyEvents`/`ApplyAndGetEvents`. Enrichers run first, then caller-supplied values are merged over the top — **the caller wins on key collision**.
+
+```csharp
+var additionalMetadata = new Dictionary<string, string> { ["idempotencyKey"] = idempotencyKey };
+
+await _customerEventRepository.ApplyEvents(
+    customerUri,
+    expectedRevision,
+    additionalMetadata,
+    cancellationToken,
+    customerCreated);
 ```
 
 # SnapshotRepository<TBaseEvent, TProjection>

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/EventRepository.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/EventRepository.cs
@@ -11,8 +11,9 @@ public class EventRepository<TBaseEvent, TSnapshot>(
     where TSnapshot : class, ISnapshot, new()
 {
     private readonly EventStoreOptions _options = options.Value;
-    private readonly IReadOnlyCollection<IEventMetadataEnricher> _metadataEnrichers =
-        (metadataEnrichers ?? Array.Empty<IEventMetadataEnricher>()).ToArray();
+    private readonly IReadOnlyCollection<IEventMetadataEnricher> _metadataEnrichers = (
+        metadataEnrichers ?? Array.Empty<IEventMetadataEnricher>()
+    ).ToArray();
 
     public async Task<TSnapshot?> Get(string id, int? revision = null, bool includeDeleted = false, CancellationToken cancellationToken = default)
     {

--- a/src/LogOtter.CosmosDb.EventStore/Repositories/EventRepository.cs
+++ b/src/LogOtter.CosmosDb.EventStore/Repositories/EventRepository.cs
@@ -2,11 +2,17 @@
 
 namespace LogOtter.CosmosDb.EventStore;
 
-public class EventRepository<TBaseEvent, TSnapshot>(EventStore<TBaseEvent> eventStore, IOptions<EventStoreOptions> options)
+public class EventRepository<TBaseEvent, TSnapshot>(
+    EventStore<TBaseEvent> eventStore,
+    IOptions<EventStoreOptions> options,
+    IEnumerable<IEventMetadataEnricher>? metadataEnrichers = null
+)
     where TBaseEvent : class, IEvent<TSnapshot>
     where TSnapshot : class, ISnapshot, new()
 {
     private readonly EventStoreOptions _options = options.Value;
+    private readonly IReadOnlyCollection<IEventMetadataEnricher> _metadataEnrichers =
+        (metadataEnrichers ?? Array.Empty<IEventMetadataEnricher>()).ToArray();
 
     public async Task<TSnapshot?> Get(string id, int? revision = null, bool includeDeleted = false, CancellationToken cancellationToken = default)
     {
@@ -55,27 +61,29 @@ public class EventRepository<TBaseEvent, TSnapshot>(EventStore<TBaseEvent> event
 
     public async Task<TSnapshot> ApplyEvents(string id, int? expectedRevision, CancellationToken cancellationToken, params TBaseEvent[] events)
     {
-        if (events.Any(e => e.EventStreamId != id))
-        {
-            throw new ArgumentException("All events must be for the same entity", nameof(events));
-        }
+        var (entity, _) = await ApplyEventsInternal(id, expectedRevision, null, cancellationToken, events);
+        return entity;
+    }
 
-        var now = DateTimeOffset.Now;
-        var streamId = _options.EscapeIdIfRequired(id);
-        var entity = await Get(id, null, true, cancellationToken) ?? new TSnapshot { Id = streamId };
-        var revision = entity.Revision;
+    public async Task<TSnapshot> ApplyEvents(
+        string id,
+        int? expectedRevision,
+        IReadOnlyDictionary<string, string>? additionalMetadata,
+        params TBaseEvent[] events
+    )
+    {
+        return await ApplyEvents(id, expectedRevision, additionalMetadata, CancellationToken.None, events);
+    }
 
-        foreach (var eventToApply in events)
-        {
-            eventToApply.Apply(entity, new(now, ++revision, new()));
-        }
-
-        var eventData = events.Select(e => new EventData<TBaseEvent>(Guid.NewGuid(), e, now)).ToArray();
-
-        await eventStore.AppendToStream(streamId, expectedRevision ?? 0, cancellationToken, eventData);
-
-        entity.Revision = revision;
-
+    public async Task<TSnapshot> ApplyEvents(
+        string id,
+        int? expectedRevision,
+        IReadOnlyDictionary<string, string>? additionalMetadata,
+        CancellationToken cancellationToken,
+        params TBaseEvent[] events
+    )
+    {
+        var (entity, _) = await ApplyEventsInternal(id, expectedRevision, additionalMetadata, cancellationToken, events);
         return entity;
     }
 
@@ -91,6 +99,38 @@ public class EventRepository<TBaseEvent, TSnapshot>(EventStore<TBaseEvent> event
         params TBaseEvent[] events
     )
     {
+        return await ApplyEventsInternal(id, expectedRevision, null, cancellationToken, events);
+    }
+
+    public async Task<(TSnapshot, EventData<TBaseEvent>[])> ApplyAndGetEvents(
+        string id,
+        int? expectedRevision,
+        IReadOnlyDictionary<string, string>? additionalMetadata,
+        params TBaseEvent[] events
+    )
+    {
+        return await ApplyAndGetEvents(id, expectedRevision, additionalMetadata, CancellationToken.None, events);
+    }
+
+    public async Task<(TSnapshot, EventData<TBaseEvent>[])> ApplyAndGetEvents(
+        string id,
+        int? expectedRevision,
+        IReadOnlyDictionary<string, string>? additionalMetadata,
+        CancellationToken cancellationToken,
+        params TBaseEvent[] events
+    )
+    {
+        return await ApplyEventsInternal(id, expectedRevision, additionalMetadata, cancellationToken, events);
+    }
+
+    private async Task<(TSnapshot, EventData<TBaseEvent>[])> ApplyEventsInternal(
+        string id,
+        int? expectedRevision,
+        IReadOnlyDictionary<string, string>? additionalMetadata,
+        CancellationToken cancellationToken,
+        TBaseEvent[] events
+    )
+    {
         if (events.Any(e => e.EventStreamId != id))
         {
             throw new ArgumentException("All events must be for the same entity", nameof(events));
@@ -101,17 +141,43 @@ public class EventRepository<TBaseEvent, TSnapshot>(EventStore<TBaseEvent> event
         var entity = await Get(id, null, true, cancellationToken) ?? new TSnapshot { Id = streamId };
         var revision = entity.Revision;
 
+        // Build once per batch: every event in the batch shares the same metadata snapshot as they
+        // all originate from the same request/trace. The dictionary is not mutated after this point,
+        // so the reference can be shared safely across the events and the in-memory apply.
+        var metadata = BuildMetadata(additionalMetadata);
+
         foreach (var eventToApply in events)
         {
-            eventToApply.Apply(entity, new(now, ++revision, new()));
+            eventToApply.Apply(entity, new(now, ++revision, metadata));
         }
 
-        var eventData = events.Select(e => new EventData<TBaseEvent>(Guid.NewGuid(), e, now)).ToArray();
+        var eventData = events.Select(e => new EventData<TBaseEvent>(Guid.NewGuid(), e, now, metadata)).ToArray();
 
         await eventStore.AppendToStream(streamId, expectedRevision ?? 0, cancellationToken, eventData);
 
         entity.Revision = revision;
 
         return (entity, eventData);
+    }
+
+    private Dictionary<string, string> BuildMetadata(IReadOnlyDictionary<string, string>? additionalMetadata)
+    {
+        var metadata = new Dictionary<string, string>();
+
+        foreach (var enricher in _metadataEnrichers)
+        {
+            enricher.Enrich(metadata);
+        }
+
+        if (additionalMetadata != null)
+        {
+            // Caller-supplied values win on key collision with enricher output.
+            foreach (var entry in additionalMetadata)
+            {
+                metadata[entry.Key] = entry.Value;
+            }
+        }
+
+        return metadata;
     }
 }

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/ActivityMetadataEnricherTests.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/ActivityMetadataEnricherTests.cs
@@ -1,0 +1,61 @@
+using System.Diagnostics;
+
+namespace LogOtter.CosmosDb.EventStore.Tests;
+
+public class ActivityMetadataEnricherTests
+{
+    private readonly ActivityMetadataEnricher _enricher = new();
+
+    [Fact]
+    public void WritesTraceParentAndTraceStateFromW3CActivity()
+    {
+        using var activity = new Activity("test");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.TraceStateString = "vendor=value";
+        activity.Start();
+
+        var metadata = new Dictionary<string, string>();
+        _enricher.Enrich(metadata);
+
+        metadata.ShouldContainKeyAndValue("traceparent", activity.Id!);
+        metadata.ShouldContainKeyAndValue("tracestate", "vendor=value");
+    }
+
+    [Fact]
+    public void OmitsTraceStateWhenEmpty()
+    {
+        using var activity = new Activity("test");
+        activity.SetIdFormat(ActivityIdFormat.W3C);
+        activity.Start();
+
+        var metadata = new Dictionary<string, string>();
+        _enricher.Enrich(metadata);
+
+        metadata.ShouldContainKey("traceparent");
+        metadata.ShouldNotContainKey("tracestate");
+    }
+
+    [Fact]
+    public void DoesNothingForHierarchicalActivity()
+    {
+        using var activity = new Activity("test");
+        activity.SetIdFormat(ActivityIdFormat.Hierarchical);
+        activity.Start();
+
+        var metadata = new Dictionary<string, string>();
+        _enricher.Enrich(metadata);
+
+        metadata.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void DoesNothingWhenNoCurrentActivity()
+    {
+        Activity.Current = null;
+
+        var metadata = new Dictionary<string, string>();
+        _enricher.Enrich(metadata);
+
+        metadata.ShouldBeEmpty();
+    }
+}

--- a/tests/LogOtter.CosmosDb.EventStore.Tests/EventRepositoryTests.cs
+++ b/tests/LogOtter.CosmosDb.EventStore.Tests/EventRepositoryTests.cs
@@ -135,13 +135,96 @@ public class EventRepositoryTests
         projection.Name.ShouldBe(newName);
     }
 
+    [Fact]
+    public async Task EnricherMetadataIsStored()
+    {
+        var (eventRepository, eventStore) = CreateEventStoreAndRepository(new StubMetadataEnricher(("traceparent", "trace-123")));
+
+        var id = Guid.NewGuid().ToString();
+        await eventRepository.ApplyEvents(id, null, new TestEventCreated(id, "Bob"));
+
+        var storedEvents = await eventStore.ReadStreamForwards(id, TestContext.Current.CancellationToken);
+        storedEvents.Single().Metadata.ShouldContainKeyAndValue("traceparent", "trace-123");
+    }
+
+    [Fact]
+    public async Task AllEventsInBatchShareEnricherMetadata()
+    {
+        var (eventRepository, eventStore) = CreateEventStoreAndRepository(new StubMetadataEnricher(("traceparent", "trace-123")));
+
+        var id = Guid.NewGuid().ToString();
+        await eventRepository.ApplyEvents(id, null, new TestEventCreated(id, "Bob"), new TestEventModified(id, "Bobby"));
+
+        var storedEvents = await eventStore.ReadStreamForwards(id, TestContext.Current.CancellationToken);
+        storedEvents.Count.ShouldBe(2);
+        storedEvents.ShouldAllBe(e => e.Metadata["traceparent"] == "trace-123");
+    }
+
+    [Fact]
+    public async Task AdditionalMetadataIsStored()
+    {
+        var (eventRepository, eventStore) = CreateEventStoreAndRepository();
+
+        var id = Guid.NewGuid().ToString();
+        var additionalMetadata = new Dictionary<string, string> { ["idempotencyKey"] = "key-1" };
+        await eventRepository.ApplyEvents(id, null, additionalMetadata, new TestEventCreated(id, "Bob"));
+
+        var storedEvents = await eventStore.ReadStreamForwards(id, TestContext.Current.CancellationToken);
+        storedEvents.Single().Metadata.ShouldContainKeyAndValue("idempotencyKey", "key-1");
+    }
+
+    [Fact]
+    public async Task AdditionalMetadataOverridesEnricherOnKeyCollision()
+    {
+        var (eventRepository, eventStore) = CreateEventStoreAndRepository(new StubMetadataEnricher(("traceparent", "from-enricher")));
+
+        var id = Guid.NewGuid().ToString();
+        var additionalMetadata = new Dictionary<string, string> { ["traceparent"] = "from-caller" };
+        await eventRepository.ApplyEvents(id, null, additionalMetadata, new TestEventCreated(id, "Bob"));
+
+        var storedEvents = await eventStore.ReadStreamForwards(id, TestContext.Current.CancellationToken);
+        storedEvents.Single().Metadata.ShouldContainKeyAndValue("traceparent", "from-caller");
+    }
+
+    [Fact]
+    public async Task NoEnrichersResultsInEmptyMetadata()
+    {
+        var (eventRepository, eventStore) = CreateEventStoreAndRepository();
+
+        var id = Guid.NewGuid().ToString();
+        await eventRepository.ApplyEvents(id, null, new TestEventCreated(id, "Bob"));
+
+        var storedEvents = await eventStore.ReadStreamForwards(id, TestContext.Current.CancellationToken);
+        storedEvents.Single().Metadata.ShouldBeEmpty();
+    }
+
     private static EventRepository<TestEvent, TestEventProjection> CreateEventRepository()
+    {
+        var (eventRepository, _) = CreateEventStoreAndRepository();
+        return eventRepository;
+    }
+
+    private static (EventRepository<TestEvent, TestEventProjection>, EventStore<TestEvent>) CreateEventStoreAndRepository(
+        params IEventMetadataEnricher[] enrichers
+    )
     {
         var container = new ContainerMock.ContainerMock();
         var feedIteratorFactory = new TestFeedIteratorFactory();
         var serializationTypeMap = new SimpleSerializationTypeMap(new[] { typeof(TestEventCreated), typeof(TestEventModified) });
         var eventStore = new EventStore<TestEvent>(container, feedIteratorFactory, serializationTypeMap);
         var options = new OptionsWrapper<EventStoreOptions>(new EventStoreOptions());
-        return new EventRepository<TestEvent, TestEventProjection>(eventStore, options);
+        var eventRepository = new EventRepository<TestEvent, TestEventProjection>(eventStore, options, enrichers);
+        return (eventRepository, eventStore);
+    }
+
+    private sealed class StubMetadataEnricher(params (string Key, string Value)[] entries) : IEventMetadataEnricher
+    {
+        public void Enrich(IDictionary<string, string> metadata)
+        {
+            foreach (var (key, value) in entries)
+            {
+                metadata[key] = value;
+            }
+        }
     }
 }


### PR DESCRIPTION
We lose context of events when emitted by CFPs so we should propogate the traceids and traceparents into the event metatdata for a given batch of events. The metadata property is already present on event records, but is always initialized as an empty dictionary.

This change adds EventMetadataEnrichers which can be registered to enrich the metadata of events with whatever data the consumers wish, while also providing a default example of ActivityMetadataEnricher to provide the traceid and traceparent which can be used for diagnostics. 